### PR TITLE
Enable account deletion and persistent profile updates

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -431,10 +431,7 @@ class ProfileScreen extends StatelessWidget {
     );
 
     if (confirm == true) {
-      // هنا يجب أن تستدعي خدمة API لحذف الحساب
-      // for example: final success = await ApiService().deleteAccount();
-      // في هذا المثال، سنفترض النجاح ونقوم بحذف البيانات محلياً
-      await userProvider.deleteAccount(); // يجب أن تتضمن هذه الدالة منطق حذف الحساب من الـ API
+      await userProvider.deleteAccount();
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -74,7 +74,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
 
     if (success) {
-      userProvider.updateUser(
+      await userProvider.updateUser(
         username: name,
         email: email,
         phone: phone,

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -216,6 +216,19 @@ Monthly Installments (4 months): ${customInstallment['monthlyPayment']} QAR each
     return response.statusCode == 200;
   }
 
+  Future<bool> deleteAccount(int userId) async {
+    final url =
+        '$baseUrl/customers/$userId?consumer_key=$ck&consumer_secret=$cs';
+
+    try {
+      final response = await http.delete(Uri.parse(url));
+      return response.statusCode == 200;
+    } catch (e) {
+      print('Error deleting account: $e');
+      return false;
+    }
+  }
+
   Future<bool> updateFcmToken(String email, String token) async {
     final url = "$baseUrl/wp-json/custom/v1/update-fcm-token";
 


### PR DESCRIPTION
## Summary
- add API helper for deleting WooCommerce customers
- call API from `UserProvider.deleteAccount`
- persist updated user info in provider
- await provider update in `SettingsScreen`
- streamline deletion confirm logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590d2a2648832a9db3d2de3aea47ac