### PR TITLE
Handle expired token on profile update

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -66,12 +66,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final phone = _phoneController.text.trim();
     final password = _passwordController.text.trim();
 
-    final success = await _apiService.updateUserInfo(
-      name: name,
-      email: email,
-      phone: phone,
-      password: password.isNotEmpty ? password : null,
-    );
+    bool success = false;
+    try {
+      success = await _apiService.updateUserInfo(
+        name: name,
+        email: email,
+        phone: phone,
+        password: password.isNotEmpty ? password : null,
+      );
+    } catch (e) {
+      if (e.toString().contains('expired_token')) {
+        if (!mounted) return;
+        _showSnackBar(isAr ? 'انتهت صلاحية الجلسة، يرجى تسجيل الدخول مرة أخرى.' : 'Session expired, please log in again.', Colors.red);
+        userProvider.logout();
+        Navigator.pushReplacementNamed(context, '/login');
+        setState(() { _isLoading = false; });
+        return;
+      }
+    }
 
     if (success) {
       await userProvider.updateUser(

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -191,10 +191,16 @@ Monthly Installments (4 months): ${customInstallment['monthlyPayment']} QAR each
 
       print("Update Response: ${response.statusCode} - ${response.body}");
 
-      return response.statusCode == 200;
+      if (response.statusCode == 200) {
+        return true;
+      } else if (response.statusCode == 403) {
+        throw Exception('expired_token');
+      } else {
+        return false;
+      }
     } catch (e) {
       print("Update Error: $e");
-      return false;
+      rethrow;
     }
   }
 


### PR DESCRIPTION
## Summary
- detect expired token when updating user info
- log out and redirect to login when the token has expired

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590ea100f4832abf12e44b572398d4