### PR TITLE
Clear stored user session during logout

### DIFF
--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -43,7 +43,16 @@ class UserProvider extends ChangeNotifier {
       ));
     }
   }
-  void logout() {
+  Future<void> logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('user_id');
+    await prefs.remove('user_token');
+    await prefs.remove('user_name');
+    await prefs.remove('user_email');
+    await prefs.remove('user_phone');
+    await prefs.remove('saved_username');
+    await prefs.remove('remember_me');
+
     _user = null;
     notifyListeners();
   }

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -371,10 +371,10 @@ class ProfileScreen extends StatelessWidget {
   }
 
   // دالة تأكيد تسجيل الخروج (مكررة من SettingsScreen مع تعديل طفيف)
-  void _confirmLogout(BuildContext context, UserProvider userProvider, bool isArabic) {
+  void _confirmLogout(BuildContext parentContext, UserProvider userProvider, bool isArabic) {
     showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
+      context: parentContext,
+      builder: (dialogContext) => AlertDialog(
         backgroundColor: Colors.white,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         title: Text(isArabic ? 'تأكيد تسجيل الخروج' : 'Confirm Logout', style: const TextStyle(color: _primaryColor)),
@@ -382,7 +382,7 @@ class ProfileScreen extends StatelessWidget {
         actions: [
           TextButton(
             child: Text(isArabic ? 'إلغاء' : 'Cancel', style: const TextStyle(color: _primaryColor)),
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => Navigator.pop(dialogContext),
           ),
           ElevatedButton(
             style: ElevatedButton.styleFrom(
@@ -390,10 +390,12 @@ class ProfileScreen extends StatelessWidget {
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
             ),
             child: Text(isArabic ? 'تسجيل الخروج' : 'Logout', style: const TextStyle(color: Colors.white)),
-            onPressed: () {
-              Navigator.pop(context);
-              userProvider.logout();
-              Navigator.pushReplacementNamed(context, '/login'); // إعادة توجيه لصفحة تسجيل الدخول
+            onPressed: () async {
+              final navigator = Navigator.of(parentContext);
+              Navigator.pop(dialogContext);
+              await userProvider.logout();
+              if (!navigator.mounted) return;
+              navigator.pushReplacementNamed('/login'); // إعادة توجيه لصفحة تسجيل الدخول
             },
           ),
         ],

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -78,9 +78,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
       if (e.toString().contains('expired_token')) {
         if (!mounted) return;
         _showSnackBar(isAr ? 'انتهت صلاحية الجلسة، يرجى تسجيل الدخول مرة أخرى.' : 'Session expired, please log in again.', Colors.red);
-        userProvider.logout();
+        await userProvider.logout();
+        if (!mounted) return;
         Navigator.pushReplacementNamed(context, '/login');
-        setState(() { _isLoading = false; });
+        setState(() {
+          _isLoading = false;
+        });
         return;
       }
     }
@@ -105,7 +108,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _confirmLogout(UserProvider userProvider, bool isAr) {
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
+      builder: (dialogContext) => AlertDialog(
         backgroundColor: Colors.white,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         title: Text(isAr ? 'تأكيد تسجيل الخروج' : 'Confirm Logout', style: const TextStyle(color: Color(0xFF1A2543))),
@@ -113,7 +116,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         actions: [
           TextButton(
             child: Text(isAr ? 'إلغاء' : 'Cancel', style: const TextStyle(color: Color(0xFF1A2543))),
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => Navigator.pop(dialogContext),
           ),
           ElevatedButton( // استخدام ElevatedButton لزر تسجيل الخروج
             style: ElevatedButton.styleFrom(
@@ -121,9 +124,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
             ),
             child: Text(isAr ? 'تسجيل الخروج' : 'Logout', style: const TextStyle(color: Colors.white)),
-            onPressed: () {
-              Navigator.pop(context);
-              userProvider.logout();
+            onPressed: () async {
+              Navigator.pop(dialogContext);
+              await userProvider.logout();
+              if (!mounted) return;
               Navigator.pushReplacementNamed(context, '/login');
             },
           ),


### PR DESCRIPTION
## Summary
- ensure `UserProvider.logout` clears all stored session keys before notifying listeners
- update settings and profile logout flows to await the asynchronous cleanup before navigation
- guard the settings session-expired flow so navigation occurs after logout completes

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc19b21e58832a857b35db3aa50622