### PR TITLE
Point mobile app at WooCommerce REST API

### DIFF
--- a/lib/constants/app_config.dart
+++ b/lib/constants/app_config.dart
@@ -1,15 +1,53 @@
 // lib/constants/app_config.dart
 
+import 'dart:convert';
+
 class AppConfig {
-  /// Base URL for the secure backend that proxies WooCommerce requests.
-  ///
-  /// The backend is responsible for handling authentication with WooCommerce
-  /// so that sensitive credentials never ship with the application binary.
+  /// Base URL for the WooCommerce REST API.
   static const String backendBaseUrl =
-      "https://creditphoneqatar.com/wp-json/app-proxy/v1";
+      "https://creditphoneqatar.com/wp-json/wc/v3";
+
+  /// Consumer key for authenticating against WooCommerce.
+  ///
+  /// Provide a value at build time using:
+  /// `flutter run --dart-define=WOO_CONSUMER_KEY=ck_xxx`.
+  static const String consumerKey =
+      String.fromEnvironment('WOO_CONSUMER_KEY', defaultValue: '');
+
+  /// Consumer secret for authenticating against WooCommerce.
+  ///
+  /// Provide a value at build time using:
+  /// `flutter run --dart-define=WOO_CONSUMER_SECRET=cs_xxx`.
+  static const String consumerSecret =
+      String.fromEnvironment('WOO_CONSUMER_SECRET', defaultValue: '');
+
+  static bool get hasWooCommerceCredentials =>
+      consumerKey.isNotEmpty && consumerSecret.isNotEmpty;
+
+  /// Basic authentication header expected by WooCommerce.
+  static Map<String, String> get wooCommerceAuthHeaders {
+    if (!hasWooCommerceCredentials) {
+      return const {};
+    }
+
+    final encoded = base64Encode(utf8.encode('$consumerKey:$consumerSecret'));
+    return {'Authorization': 'Basic $encoded'};
+  }
+
+  /// Query parameters for authenticating WooCommerce requests.
+  static Map<String, String> get wooCommerceAuthQueryParameters {
+    if (!hasWooCommerceCredentials) {
+      return const {};
+    }
+
+    return {
+      'consumer_key': consumerKey,
+      'consumer_secret': consumerSecret,
+    };
+  }
 
   /// Helper for building a backend [Uri] with optional query parameters while
-  /// skipping null values.
+  /// skipping null values and automatically appending WooCommerce credentials.
   static Uri buildBackendUri(
     String path, {
     Map<String, dynamic>? queryParameters,
@@ -17,14 +55,16 @@ class AppConfig {
     final normalizedPath = path.startsWith('/') ? path : '/$path';
     final uri = Uri.parse('$backendBaseUrl$normalizedPath');
 
-    if (queryParameters == null || queryParameters.isEmpty) {
-      return uri;
+    final sanitized = <String, String>{};
+    if (queryParameters != null && queryParameters.isNotEmpty) {
+      queryParameters.forEach((key, value) {
+        if (value == null) return;
+        sanitized[key] = value.toString();
+      });
     }
 
-    final sanitized = <String, String>{};
-    queryParameters.forEach((key, value) {
-      if (value == null) return;
-      sanitized[key] = value.toString();
+    AppConfig.wooCommerceAuthQueryParameters.forEach((key, value) {
+      sanitized.putIfAbsent(key, () => value);
     });
 
     if (sanitized.isEmpty) {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -47,6 +47,8 @@ class AuthService {
       AppConfig.buildBackendUri('/customers'),
       headers: {
         "Content-Type": "application/json",
+        'Accept': 'application/json',
+        ...AppConfig.wooCommerceAuthHeaders,
       },
       body: jsonEncode({
         "email": email,
@@ -72,6 +74,7 @@ class AuthService {
       }
 
       return User.fromJson({
+        "id": customerData["id"],
         "token": "",
         "user_display_name":
             customerData["username"] ?? customerData["name"] ?? "",


### PR DESCRIPTION
## Summary
- point the mobile configuration at the WooCommerce REST API and allow the consumer key and secret to be injected at build time
- update the API service to call WooCommerce endpoints directly, add shared auth headers/query params, and adjust order/customer helpers to the new contract
- ensure customer registration sends WooCommerce auth headers and captures the returned customer id for later use

## Testing
- not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc306dbd6c832a8668038e0171fc0a