### PR TITLE
Initialize home categories future eagerly

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -27,7 +27,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin, 
   @override
   bool get wantKeepAlive => true;
   final apiService = ApiService();
-  late Future<List<Category>> _futureCategories;
+  Future<List<Category>> _futureCategories = Future.value(const []);
   final ValueNotifier<int> _notificationCount = ValueNotifier<int>(0);
   final List<int> topRequestedProductIdsAr = [12226, 12261, 12245, 12762];
   final List<int> topRequestedProductIdsEn = [12902, 13310, 13325, 12835];
@@ -61,9 +61,11 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin, 
       curve: Curves.easeOutCubic,
     );
 
+    final localeProvider = Provider.of<LocaleProvider>(context, listen: false);
+    _futureCategories =
+        apiService.getCategories(language: localeProvider.locale.languageCode);
+
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final localeProvider = Provider.of<LocaleProvider>(context, listen: false);
-      _loadData(localeProvider.locale.languageCode);
       _startNotificationPolling();
       _startAnimations();
       await _checkFirstTime(); // ← اجعلها async


### PR DESCRIPTION
## Summary
- initialize the home screen categories future with an empty list placeholder
- kick off the initial categories fetch during initState before the first frame
- remove the redundant post-frame reload to rely on the initialized future

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc353de12c832a9ddaa935e10e6953