### PR TITLE
Configure WooCommerce credentials via dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# WooCommerce REST API credentials
+WOO_CONSUMER_KEY=ck_your_consumer_key
+WOO_CONSUMER_SECRET=cs_your_consumer_secret

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Environment configuration
+.env

--- a/README.md
+++ b/README.md
@@ -1,16 +1,62 @@
-# creditphoneqa
+# Credit Phone Qatar mobile app
 
-A new Flutter project.
+This Flutter application consumes the WooCommerce API hosted at
+`https://creditphoneqatar.com`. The store requires authenticated requests, so
+each build must provide a WooCommerce consumer key and secret.
 
-## Getting Started
+## Environment configuration
 
-This project is a starting point for a Flutter application.
+The application reads credentials from a `.env` file via
+[`flutter_dotenv`](https://pub.dev/packages/flutter_dotenv). Copy the example
+file and fill in the values provided by the WooCommerce backend team:
 
-A few resources to get you started if this is your first Flutter project:
+```bash
+cp .env.example .env
+```
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+Update the generated `.env` file so it contains the correct keys:
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+```text
+WOO_CONSUMER_KEY=ck_live_value
+WOO_CONSUMER_SECRET=cs_live_value
+```
+
+The file is ignored by Git, ensuring secrets remain local to your machine.
+
+### Alternative: CI/CD environments
+
+CI pipelines that should not manage files can pass the credentials with
+`--dart-define` flags. The application falls back to these at runtime when the
+`.env` file is unavailable:
+
+```bash
+flutter run \
+  --dart-define=WOO_CONSUMER_KEY=ck_live_value \
+  --dart-define=WOO_CONSUMER_SECRET=cs_live_value
+```
+
+When using CI, ensure the job exports these flags for any `flutter run`,
+`flutter test`, or `flutter build` invocation so HTTP requests are authorized.
+
+## Running the app locally
+
+1. Install Flutter (version 3.6.0 or newer) and the platform SDKs required for
+   your target (Android/iOS/etc.).
+2. Create the `.env` file or set `--dart-define` flags as described above.
+3. Fetch dependencies and launch the app:
+
+   ```bash
+   flutter pub get
+   flutter run
+   ```
+
+On first launch the catalog should populate again—check the debug console for
+HTTP 200 responses from the WooCommerce `/products` and `/categories` routes.
+
+## Troubleshooting
+
+- `dotenv: Unable to load asset: .env`: ensure the `.env` file exists at the
+  project root or provide credentials via `--dart-define`.
+- Empty catalog: verify both `WOO_CONSUMER_KEY` and `WOO_CONSUMER_SECRET` are
+  provided. The app only attempts authenticated requests when both values are
+  non-empty.

--- a/lib/constants/app_config.dart
+++ b/lib/constants/app_config.dart
@@ -1,25 +1,48 @@
-// lib/constants/app_config.dart
-
 import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class AppConfig {
   /// Base URL for the WooCommerce REST API.
   static const String backendBaseUrl =
       "https://creditphoneqatar.com/wp-json/wc/v3";
 
+  static String get _consumerKeyFromDartDefine => const String.fromEnvironment(
+        'WOO_CONSUMER_KEY',
+        defaultValue: '',
+      );
+
+  static String get _consumerSecretFromDartDefine =>
+      const String.fromEnvironment(
+        'WOO_CONSUMER_SECRET',
+        defaultValue: '',
+      );
+
   /// Consumer key for authenticating against WooCommerce.
   ///
-  /// Provide a value at build time using:
-  /// `flutter run --dart-define=WOO_CONSUMER_KEY=ck_xxx`.
-  static const String consumerKey =
-      String.fromEnvironment('ck_3344026e4d873a6013ec165a13277bc826bd7e7e', defaultValue: '');
+  /// Values are loaded from the runtime environment using [flutter_dotenv]
+  /// and fall back to a `--dart-define` flag so CI can inject secrets without
+  /// creating files on disk.
+  static String get consumerKey {
+    final envValue = dotenv.env['WOO_CONSUMER_KEY']?.trim();
+    if (envValue != null && envValue.isNotEmpty) {
+      return envValue;
+    }
+    return _consumerKeyFromDartDefine;
+  }
 
   /// Consumer secret for authenticating against WooCommerce.
   ///
-  /// Provide a value at build time using:
-  /// `flutter run --dart-define=WOO_CONSUMER_SECRET=cs_xxx`.
-  static const String consumerSecret =
-      String.fromEnvironment('cs_fa6a8b8eb7643166eede6750a1a6538c4334d027', defaultValue: '');
+  /// Values are loaded from the runtime environment using [flutter_dotenv]
+  /// and fall back to a `--dart-define` flag so CI can inject secrets without
+  /// creating files on disk.
+  static String get consumerSecret {
+    final envValue = dotenv.env['WOO_CONSUMER_SECRET']?.trim();
+    if (envValue != null && envValue.isNotEmpty) {
+      return envValue;
+    }
+    return _consumerSecretFromDartDefine;
+  }
 
   static bool get hasWooCommerceCredentials =>
       consumerKey.isNotEmpty && consumerSecret.isNotEmpty;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:creditphoneqa/services/notification_service.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'routes.dart';
 import 'providers/cart_provider.dart';
@@ -12,8 +14,20 @@ import 'providers/locale_provider.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'theme.dart';
 
+Future<void> _loadEnvironment() async {
+  try {
+    await dotenv.load(fileName: '.env');
+  } on FlutterError catch (error) {
+    debugPrint('dotenv: ${error.message}');
+  } catch (error, stackTrace) {
+    debugPrint('Failed to load .env file: $error');
+    debugPrint('$stackTrace');
+  }
+}
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await _loadEnvironment();
   await Firebase.initializeApp();
   FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
   await NotificationService().initialize();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   firebase_messaging: ^15.2.5
   flutter_local_notifications: ^19.0.0
   audioplayers: ^6.4.0
+  flutter_dotenv: ^5.1.0
 
 
 dev_dependencies:
@@ -76,6 +77,7 @@ flutter:
     - assets/images/logo_login.png
     - assets/sounds/click.mp3
     - assets/sounds/delete.mp3
+    - .env
 
 
   fonts:


### PR DESCRIPTION
## Summary
- add flutter_dotenv support so WooCommerce credentials load from a secure `.env` file or dart-define flags
- initialize the dotenv loader during app bootstrap and consume the secrets in `AppConfig`
- document the new setup flow, provide an `.env` example, and ignore real secrets in git

## Testing
- not run (Flutter SDK unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc35dfdbe8832aa296d892a0a442b4