### PR TITLE
Ensure user ID persistence through login flow

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -14,13 +14,34 @@ class User {
   });
 
   factory User.fromJson(Map<String, dynamic> json) {
+    final Map<String, dynamic>? dataSection =
+        json['data'] is Map ? Map<String, dynamic>.from(json['data']) : null;
+
+    final Map<String, dynamic>? customerSection = json['customer'] is Map
+        ? Map<String, dynamic>.from(json['customer'])
+        : null;
+
+    final dynamic idSource = json['id'] ??
+        json['user_id'] ??
+        json['ID'] ??
+        (dataSection?['id']) ??
+        (dataSection?['user_id']) ??
+        (customerSection?['id']);
+
     return User(
-      id: json['id'],
+      id: _parseId(idSource),
       token: json["token"] ?? "",
       username: json["user_display_name"] ?? json["first_name"] ?? "",
       email: json["user_email"] ?? json["email"] ?? "",
       phone: json["phone"] ?? json["billing"]?["phone"] ?? "",
     );
+  }
+
+  static int? _parseId(dynamic id) {
+    if (id is int) return id;
+    if (id is String) return int.tryParse(id);
+    if (id is double) return id.toInt();
+    return null;
   }
 
   User copyWith({

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -17,7 +17,11 @@ class UserProvider extends ChangeNotifier {
     notifyListeners();
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt('user_id', newUser.id ?? 0);
+    if (newUser.id != null) {
+      await prefs.setInt('user_id', newUser.id!);
+    } else {
+      await prefs.remove('user_id');
+    }
     await prefs.setString('user_token', newUser.token);
     await prefs.setString('user_name', newUser.username);
     await prefs.setString('user_email', newUser.email);

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -85,6 +85,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
           _isLoading = false;
         });
         return;
+      } else if (e.toString().contains('user_id_missing')) {
+        if (!mounted) return;
+        _showSnackBar(
+          isAr
+              ? 'لم يتم العثور على معرف المستخدم. يرجى تسجيل الخروج ثم تسجيل الدخول مرة أخرى لإعادة المزامنة.'
+              : 'User ID is missing. Please log out and log in again to refresh your data.',
+          Colors.orange,
+        );
+        setState(() {
+          _isLoading = false;
+        });
+        return;
       }
     }
 


### PR DESCRIPTION
## Summary
- extend `User.fromJson` to accept additional identifier keys returned by the login API
- persist the resolved user ID in SharedPreferences during login and when updating the provider
- show a contextual message on the settings screen when profile updates fail because the user ID is missing

## Testing
- `flutter test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd14f6d770832a85851a583c562fc6