### PR TITLE
Add installment-focused product listing and navigation

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'screens/about_screen.dart';
 import 'screens/faq_screen.dart';
 import 'screens/installment_options_screen.dart';
+import 'screens/installment_store_screen.dart';
 import 'screens/splash_screen.dart';
 import 'screens/login_screen.dart';
 import 'screens/register_screen.dart'; // تأكد من وجود هذا الملف
@@ -41,6 +42,7 @@ class AppRoutes {
     '/about': (context) => const AboutUsScreen(),
     '/faq': (context) => const FaqScreen(),
     '/installment-options': (context) => const InstallmentOptionsScreen(),
+    '/installment-store': (context) => const InstallmentStoreScreen(),
 
 
   };

--- a/lib/screens/installment_store_screen.dart
+++ b/lib/screens/installment_store_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import 'product_list_screen.dart';
+
+class InstallmentStoreScreen extends StatelessWidget {
+  const InstallmentStoreScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const ProductListScreen(
+      showInstallmentOnly: true,
+      titleAr: 'متجر التقسيط',
+      titleEn: 'Installment Store',
+      searchHintAr: 'ابحث عن عروض التقسيط...',
+      searchHintEn: 'Search for installment deals...',
+      noResultsTextAr: 'لا توجد عروض تقسيط متاحة حالياً',
+      noResultsTextEn: 'No installment offers available right now',
+    );
+  }
+}

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -8,6 +8,7 @@ import '../providers/user_provider.dart';
 import 'home_screen.dart';
 import 'cart_screen.dart';
 import 'profile_screen.dart';
+import 'installment_store_screen.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({Key? key}) : super(key: key);
@@ -23,6 +24,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
 
   final List<Widget> _screens = const [
     HomeScreen(),
+    InstallmentStoreScreen(),
     CartScreen(),
     ProfileScreen(),
   ];
@@ -60,8 +62,8 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     final isArabic = languageCode == 'ar';
 
     final navLabels = isArabic
-        ? ['الرئيسية', 'السلة', 'حسابي']
-        : ['Home', 'Cart', 'Profile'];
+        ? ['الرئيسية', 'تقسيط', 'السلة', 'حسابي']
+        : ['Home', 'Installments', 'Cart', 'Profile'];
 
     return Directionality(
       textDirection: isArabic ? TextDirection.rtl : TextDirection.ltr,
@@ -157,22 +159,28 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
                       delay: 100,
                     ),
                     _buildAnimatedDrawerItem(
+                      Icons.payments_rounded,
+                      isAr ? "متجر التقسيط" : "Installment Store",
+                          () => _navigateFromDrawer(context, '/installment-store'),
+                      delay: 200,
+                    ),
+                    _buildAnimatedDrawerItem(
                       Icons.shopping_bag_rounded,
                       isAr ? "السلة" : "Cart",
                           () => _navigateFromDrawer(context, '/cart'),
-                      delay: 200,
+                      delay: 300,
                     ),
                     _buildAnimatedDrawerItem(
                       Icons.receipt_long_rounded,
                       isAr ? "طلباتي" : "Orders",
                           () => _navigateFromDrawer(context, isLoggedIn ? '/orders' : '/login'),
-                      delay: 300,
+                      delay: 400,
                     ),
                     _buildAnimatedDrawerItem(
                       Icons.settings_rounded,
                       isAr ? "الإعدادات / Settings" : "الإعدادات / Settings",
                           () => _navigateFromDrawer(context, '/settings'),
-                      delay: 400,
+                      delay: 500,
                     ),
                     // خط فاصل أنيق
                     Container(
@@ -192,31 +200,31 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
                       Icons.support_agent_rounded,
                       isAr ? "تواصل معنا" : "Contact Us",
                           () => _showContactDialog(context, isAr),
-                      delay: 500,
+                      delay: 600,
                     ),
                     _buildAnimatedDrawerItem(
                       Icons.lock_person_rounded,
                       isAr ? "سياسة الخصوصية" : "Privacy Policy",
                           () => _navigateFromDrawer(context, '/privacy'),
-                      delay: 600,
+                      delay: 700,
                     ),
                     _buildAnimatedDrawerItem(
                       Icons.rule_folder_rounded,
                       isAr ? "شروط الاستخدام" : "Terms of Use",
                           () => _navigateFromDrawer(context, '/terms'),
-                      delay: 700,
+                      delay: 800,
                     ),
                     _buildAnimatedDrawerItem(
                       Icons.info_rounded,
                       isAr ? "نبذة عنا" : "About Us",
                           () => _navigateFromDrawer(context, '/about'),
-                      delay: 800,
+                      delay: 900,
                     ),
                     _buildAnimatedDrawerItem(
                       Icons.help_outline_rounded,
                       isAr ? "الأسئلة الشائعة" : "FAQs",
                           () => _navigateFromDrawer(context, '/faq'),
-                      delay: 900,
+                      delay: 1000,
                       isLast: true, // للإشارة إلى العنصر الأخير لتعديل الهامش
                     ),
                   ],
@@ -613,13 +621,17 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
                 label: navLabels[0],
               ),
               BottomNavigationBarItem(
+                icon: _buildEnhancedNavIcon(Icons.payments_rounded, 1),
+                label: navLabels[1],
+              ),
+              BottomNavigationBarItem(
                 icon: Consumer<CartProvider>(
                   builder: (context, cartProvider, child) {
                     int count = cartProvider.items.fold(0, (sum, item) => sum + item.quantity);
                     return Stack(
                       clipBehavior: Clip.none, // للسماح للشارة بالظهور خارج الحدود
                       children: [
-                        _buildEnhancedNavIcon(Icons.shopping_bag_rounded, 1),
+                        _buildEnhancedNavIcon(Icons.shopping_bag_rounded, 2),
                         if (count > 0) // إظهار الشارة فقط إذا كان هناك عناصر في السلة
                           Positioned(
                             right: -8,
@@ -657,11 +669,11 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
                     );
                   },
                 ),
-                label: navLabels[1],
+                label: navLabels[2],
               ),
               BottomNavigationBarItem(
-                icon: _buildEnhancedNavIcon(Icons.account_circle_rounded, 2),
-                label: navLabels[2],
+                icon: _buildEnhancedNavIcon(Icons.account_circle_rounded, 3),
+                label: navLabels[3],
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- extend `ProductListScreen` with installment-only filtering and localized text overrides
- add a reusable `InstallmentStoreScreen` that surfaces installment products with bilingual labels
- wire the installment store into the main navigation, drawer shortcuts, and global routes

## Testing
- dart format lib/screens/product_list_screen.dart lib/screens/installment_store_screen.dart lib/screens/main_screen.dart lib/routes.dart *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd17ce7848832a8a00f9148aa18940