### PR TITLE
Show cash-only products from home category card

### DIFF
--- a/lib/widgets/home_card_category.dart
+++ b/lib/widgets/home_card_category.dart
@@ -15,7 +15,10 @@ class HomeCategoryCard extends StatelessWidget {
         onTap: () => Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (ctx) => ProductListScreen(categoryId: category.id),
+            builder: (ctx) => ProductListScreen(
+              categoryId: category.id,
+              showCashOnly: true,
+            ),
           ),
         ),
         borderRadius: BorderRadius.circular(20),


### PR DESCRIPTION
## Summary
- ensure the home category card navigates to a cash-only product list by setting `showCashOnly` on `ProductListScreen`

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1e636e48832ab90495786ff2d114