### PR TITLE
Ensure category cards open cash-only product list

### DIFF
--- a/lib/widgets/category_card.dart
+++ b/lib/widgets/category_card.dart
@@ -21,7 +21,10 @@ class CategoryCard extends StatelessWidget {
         onTap: () => Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (ctx) => ProductListScreen(categoryId: category.id),
+            builder: (ctx) => ProductListScreen(
+              categoryId: category.id,
+              showCashOnly: true,
+            ),
           ),
         ),
         borderRadius: BorderRadius.circular(18), // Match card's border radius


### PR DESCRIPTION
## Summary
- pass showCashOnly: true when navigating from category cards to the product list
- ensure the categories flow consistently opens cash-only listings

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1ec73270832ab1317f7163961027