### PR TITLE
Enable navigation from installment categories

### DIFF
--- a/lib/screens/installment_store_screen.dart
+++ b/lib/screens/installment_store_screen.dart
@@ -219,26 +219,53 @@ class _InstallmentStoreScreenState extends State<InstallmentStoreScreen> {
             itemCount: categories.length,
             itemBuilder: (context, index) {
               final category = categories[index];
-              return Container(
-                width: 100,
-                margin: const EdgeInsets.symmetric(horizontal: 8),
-                decoration: BoxDecoration(
-                  color: Colors.white,
+              final splashColor = const Color(0xFF6FE0DA).withOpacity(0.2);
+              final highlightColor = const Color(0xFF6FE0DA).withOpacity(0.1);
+              return Material(
+                color: Colors.transparent,
+                borderRadius: BorderRadius.circular(12),
+                child: InkWell(
                   borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: Colors.grey.withOpacity(0.15)),
-                ),
-                child: Center(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: Text(
-                      category.name,
-                      textAlign: TextAlign.center,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF1A2543),
-                        fontWeight: FontWeight.w600,
+                  splashColor: splashColor,
+                  highlightColor: highlightColor,
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => ProductListScreen(
+                          categoryId: category.id,
+                          showInstallmentOnly: true,
+                          titleAr: 'متجر التقسيط',
+                          titleEn: 'Installment Store',
+                          searchHintAr: 'ابحث عن عروض التقسيط...',
+                          searchHintEn: 'Search for installment deals...',
+                        ),
+                      ),
+                    );
+                    HapticFeedback.lightImpact();
+                  },
+                  child: Container(
+                    width: 100,
+                    margin: const EdgeInsets.symmetric(horizontal: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(color: Colors.grey.withOpacity(0.15)),
+                    ),
+                    child: Center(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        child: Text(
+                          category.name,
+                          textAlign: TextAlign.center,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF1A2543),
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Summary
- wrap each installment category chip in a Material/InkWell to capture taps
- navigate to `ProductListScreen` with the tapped `categoryId` and `showInstallmentOnly: true`
- add subtle splash/highlight colors to give visual feedback when a category is pressed

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1f41fba4832aadf8ef54a03e9809