### PR TITLE
Handle empty profile initials safely

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -200,6 +200,39 @@ class ProfileScreen extends StatelessWidget {
 
     final user = userProvider.user!;
 
+    String? _extractInitial(String value) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty) {
+        return null;
+      }
+      final firstCodeUnit = trimmed.runes.first;
+      final firstCharacter = String.fromCharCode(firstCodeUnit);
+      return firstCharacter.toUpperCase();
+    }
+
+    String _deriveInitial() {
+      return _extractInitial(user.username) ??
+          _extractInitial(user.email) ??
+          '?';
+    }
+
+    String _deriveDisplayName() {
+      final trimmedUsername = user.username.trim();
+      if (trimmedUsername.isNotEmpty) {
+        return trimmedUsername;
+      }
+
+      final trimmedEmail = user.email.trim();
+      if (trimmedEmail.isNotEmpty) {
+        return trimmedEmail;
+      }
+
+      return isArabic ? 'صديقنا' : 'there';
+    }
+
+    final profileInitial = _deriveInitial();
+    final displayName = _deriveDisplayName();
+
     return ListView(
       padding: const EdgeInsets.all(20), // حشوة أكبر
       physics: const BouncingScrollPhysics(), // تأثير ارتداد عند التمرير
@@ -217,13 +250,13 @@ class ProfileScreen extends StatelessWidget {
                   radius: 45, // حجم أكبر للصورة الرمزية
                   backgroundColor: _accentColor, // اللون الثانوي للهوية
                   child: Text(
-                    user.username[0].toUpperCase(),
+                    profileInitial,
                     style: const TextStyle(fontSize: 36, color: Colors.white, fontWeight: FontWeight.bold), // خط أكبر وأسمك
                   ),
                 ),
                 const SizedBox(height: 16), // مسافة أكبر
                 Text(
-                  isArabic ? "مرحباً، ${user.username}!" : "Hello, ${user.username}!", // إضافة علامة تعجب
+                  isArabic ? "مرحباً، $displayName!" : "Hello, $displayName!", // إضافة علامة تعجب
                   style: const TextStyle(fontSize: 22, color: Colors.white, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 8), // مسافة أكبر

--- a/test/profile_screen_test.dart
+++ b/test/profile_screen_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:creditphoneqa/models/user.dart';
+import 'package:creditphoneqa/providers/locale_provider.dart';
+import 'package:creditphoneqa/providers/user_provider.dart';
+import 'package:creditphoneqa/screens/profile_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('ProfileScreen shows fallback initial for empty username', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    final userProvider = UserProvider();
+    final localeProvider = LocaleProvider();
+
+    await localeProvider.setLocale(const Locale('en'));
+
+    userProvider.setUser(
+      User(
+        id: 1,
+        token: 'token',
+        username: '',
+        email: 'tester@example.com',
+        phone: '',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<UserProvider>.value(value: userProvider),
+          ChangeNotifierProvider<LocaleProvider>.value(value: localeProvider),
+        ],
+        child: const MaterialApp(
+          home: ProfileScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('T'), findsOneWidget);
+    expect(find.text('Hello, tester@example.com!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- derive profile initials and greeting text from the first available user identifier
- fall back to a friendly default when no username or email is available
- add a widget test to ensure the profile screen handles empty usernames without crashing

## Testing
- `flutter test test/profile_screen_test.dart` *(fails: `flutter` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d902467f8c832a8049d483f3677397