### PR TITLE
Clear notification data when logging out

### DIFF
--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/user.dart';
 import '../services/api_service.dart';
+import '../services/notification_service.dart';
 
 class UserProvider extends ChangeNotifier {
   User? _user;
@@ -56,6 +57,8 @@ class UserProvider extends ChangeNotifier {
     await prefs.remove('user_phone');
     await prefs.remove('saved_username');
     await prefs.remove('remember_me');
+    await NotificationService.clearStoredData();
+    await prefs.remove('fcm_token');
 
     _user = null;
     notifyListeners();

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -19,6 +19,21 @@ class NotificationService {
   static const String _unreadCountKey = 'unread_notifications';
   static StreamSubscription<RemoteMessage>? _foregroundSubscription;
 
+  /// Clears stored notification-related data from [SharedPreferences].
+  static Future<void> clearStoredData() async {
+    final prefs = await SharedPreferences.getInstance();
+    const keysToRemove = <String>[
+      _notificationsListKey,
+      _unreadCountKey,
+      _notificationsEnabledKey,
+      'order_statuses',
+    ];
+
+    for (final key in keysToRemove) {
+      await prefs.remove(key);
+    }
+  }
+
   Future<void> initialize() async {
     final prefs = await SharedPreferences.getInstance();
     final bool notificationsEnabled = prefs.getBool(_notificationsEnabledKey) ?? true;

--- a/test/user_logout_notifications_test.dart
+++ b/test/user_logout_notifications_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:creditphoneqa/models/user.dart';
+import 'package:creditphoneqa/providers/user_provider.dart';
+import 'package:creditphoneqa/services/notification_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('logout clears notification data for next user session', () async {
+    SharedPreferences.setMockInitialValues({
+      'notifications': <String>['{"title":"old"}'],
+      'unread_notifications': 3,
+      'order_statuses': '{"1":"pending"}',
+      'notifications_enabled': false,
+      'fcm_token': 'old-token',
+      'user_token': 'token-a',
+      'user_name': 'user-a',
+      'user_email': 'a@example.com',
+      'user_phone': '123456',
+    });
+
+    final provider = UserProvider();
+    provider.setUser(
+      User(
+        id: 1,
+        token: 'token-a',
+        username: 'user-a',
+        email: 'a@example.com',
+        phone: '123456',
+      ),
+    );
+
+    await provider.logout();
+
+    final prefs = await SharedPreferences.getInstance();
+    final notifications = await NotificationService().getAllNotifications();
+
+    expect(provider.user, isNull);
+    expect(notifications, isEmpty);
+    expect(prefs.containsKey('notifications'), isFalse);
+    expect(prefs.containsKey('unread_notifications'), isFalse);
+    expect(prefs.containsKey('order_statuses'), isFalse);
+    expect(prefs.containsKey('notifications_enabled'), isFalse);
+    expect(prefs.containsKey('fcm_token'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add a helper in `NotificationService` to clear cached notification data from SharedPreferences
- invoke the new helper and remove the stored FCM token as part of `UserProvider.logout`
- add a provider-focused test to verify notification data is cleared during logout

## Testing
- `flutter test test/user_logout_notifications_test.dart` *(fails: Flutter SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90315c708832a9399740809693d55