### PR TITLE
Add logout cleanup workflow for notification service

### DIFF
--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -7,6 +7,10 @@ import '../services/api_service.dart';
 import '../services/notification_service.dart';
 
 class UserProvider extends ChangeNotifier {
+  UserProvider({NotificationService? notificationService})
+      : _notificationService = notificationService ?? NotificationService();
+
+  final NotificationService _notificationService;
   User? _user;
 
   User? get user => _user;
@@ -49,6 +53,9 @@ class UserProvider extends ChangeNotifier {
     }
   }
   Future<void> logout() async {
+    final email = _user?.email;
+    await _notificationService.logoutCleanup(email: email);
+
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('user_id');
     await prefs.remove('user_token');
@@ -57,8 +64,6 @@ class UserProvider extends ChangeNotifier {
     await prefs.remove('user_phone');
     await prefs.remove('saved_username');
     await prefs.remove('remember_me');
-    await NotificationService.clearStoredData();
-    await prefs.remove('fcm_token');
 
     _user = null;
     notifyListeners();

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -334,4 +334,21 @@ Monthly Installments (4 months): ${customInstallment['monthlyPayment']} QAR each
       return false;
     }
   }
+
+  Future<bool> unregisterFcmToken(String email) async {
+    try {
+      final response = await http.delete(
+        Uri.parse('https://creditphoneqatar.com/wp-json/app/v1/notifications/fcm'),
+        headers: const {"Content-Type": "application/json"},
+        body: jsonEncode({
+          "email": email,
+        }),
+      );
+
+      return response.statusCode == 200 || response.statusCode == 204;
+    } catch (e) {
+      print('Error unregistering FCM token: $e');
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add a configurable logoutCleanup workflow in NotificationService that stops listeners, clears storage, removes the device token, and unregisters it from the backend
- allow UserProvider to inject NotificationService, call the new cleanup logic before clearing user data, and extend ApiService with an unregisterFcmToken helper
- update the logout notification test to use fakes that assert token deletion and API unregister behavior

## Testing
- `flutter test test/user_logout_notifications_test.dart` *(fails: flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d905515eb0832aa3cc463014f91935