### PR TITLE
Add localized validation to register form

### DIFF
--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -12,6 +12,7 @@ class RegisterScreen extends StatefulWidget {
 }
 
 class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
   final _usernameController = TextEditingController();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
@@ -21,10 +22,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
   bool _loading = false;
 
   void _register() async {
-    if (_passwordController.text != _confirmController.text) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("كلمة المرور غير متطابقة")),
-      );
+    final localeProvider = Provider.of<LocaleProvider>(context, listen: false);
+    final language = localeProvider.locale.languageCode;
+
+    if (!(_formKey.currentState?.validate() ?? false)) {
       return;
     }
 
@@ -47,7 +48,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
       Navigator.pushNamedAndRemoveUntil(context, '/main', (route) => false);
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("فشل: $e")),
+        SnackBar(
+          content: Text(language == "ar" ? "فشل: $e" : "Failed: $e"),
+        ),
       );
     } finally {
       setState(() => _loading = false);
@@ -68,123 +71,180 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
     final size = MediaQuery.of(context).size;
 
+    final String usernameError = language == "ar"
+        ? "يرجى إدخال اسم المستخدم"
+        : "Please enter a username";
+    final String emailError = language == "ar"
+        ? "يرجى إدخال بريد إلكتروني صالح"
+        : "Please enter a valid email";
+    final String phoneError = language == "ar"
+        ? "يرجى إدخال رقم جوال"
+        : "Please enter a phone number";
+    final String passwordError = language == "ar"
+        ? "يرجى إدخال كلمة المرور"
+        : "Please enter a password";
+    final String confirmEmptyError = language == "ar"
+        ? "يرجى تأكيد كلمة المرور"
+        : "Please confirm your password";
+    final String confirmError = language == "ar"
+        ? "كلمة المرور غير متطابقة"
+        : "Passwords do not match";
+
     return Scaffold(
       backgroundColor: Colors.white,
       body: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 30),
-          child: Column(
-            children: [
-              SizedBox(height: size.height * 0.12),
-              Image.asset(
-                'assets/images/logo_login.png',
-                height: 200, // تم تكبير الشعار
-              ),
-              const SizedBox(height: 30),
-              Text(
-                titleText,
-                style: const TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
-                  color: Color(0xFF1A2543),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              children: [
+                SizedBox(height: size.height * 0.12),
+                Image.asset(
+                  'assets/images/logo_login.png',
+                  height: 200, // تم تكبير الشعار
                 ),
-              ),
-              const SizedBox(height: 30),
-              TextField(
-                controller: _usernameController,
-                decoration: InputDecoration(
-                  prefixIcon: const Icon(Icons.person, color: Color(0xFF1A2543)),
-                  hintText: usernameHint,
-                  filled: true,
-                  fillColor: Colors.grey[100],
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide.none,
+                const SizedBox(height: 30),
+                Text(
+                  titleText,
+                  style: const TextStyle(
+                    fontSize: 28,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF1A2543),
                   ),
                 ),
-              ),
-              const SizedBox(height: 20),
-              TextField(
-                controller: _emailController,
-                keyboardType: TextInputType.emailAddress,
-                decoration: InputDecoration(
-                  prefixIcon: const Icon(Icons.email, color: Color(0xFF1A2543)),
-                  hintText: emailHint,
-                  filled: true,
-                  fillColor: Colors.grey[100],
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide.none,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 20),
-              TextField(
-                controller: _phoneController,
-                keyboardType: TextInputType.phone,
-                decoration: InputDecoration(
-                  prefixIcon: const Icon(Icons.phone, color: Color(0xFF1A2543)),
-                  hintText: language == "ar" ? "رقم الجوال" : "Phone",
-                  filled: true,
-                  fillColor: Colors.grey[100],
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide.none,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 20),
-              TextField(
-                controller: _passwordController,
-                obscureText: true,
-                decoration: InputDecoration(
-                  prefixIcon: const Icon(Icons.lock, color: Color(0xFF1A2543)),
-                  hintText: passwordHint,
-                  filled: true,
-                  fillColor: Colors.grey[100],
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide.none,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 20),
-              TextField(
-                controller: _confirmController,
-                obscureText: true,
-                decoration: InputDecoration(
-                  prefixIcon: const Icon(Icons.lock_outline, color: Color(0xFF1A2543)),
-                  hintText: confirmHint,
-                  filled: true,
-                  fillColor: Colors.grey[100],
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide.none,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 30),
-              _loading
-                  ? const CircularProgressIndicator(color: Color(0xFF1A2543))
-                  : SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: _register,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF1A2543),
-                    minimumSize: const Size(0, 50),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16),
+                const SizedBox(height: 30),
+                TextFormField(
+                  controller: _usernameController,
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return usernameError;
+                    }
+                    return null;
+                  },
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.person, color: Color(0xFF1A2543)),
+                    hintText: usernameHint,
+                    filled: true,
+                    fillColor: Colors.grey[100],
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
                     ),
                   ),
-                  child: Text(
-                    buttonText,
-                    style: const TextStyle(fontSize: 18, color: Colors.white),
+                ),
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  validator: (value) {
+                    final email = value?.trim() ?? '';
+                    final emailRegex = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+                    if (!emailRegex.hasMatch(email)) {
+                      return emailError;
+                    }
+                    return null;
+                  },
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.email, color: Color(0xFF1A2543)),
+                    hintText: emailHint,
+                    filled: true,
+                    fillColor: Colors.grey[100],
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 20),
-            ],
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _phoneController,
+                  keyboardType: TextInputType.phone,
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return phoneError;
+                    }
+                    return null;
+                  },
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.phone, color: Color(0xFF1A2543)),
+                    hintText: language == "ar" ? "رقم الجوال" : "Phone",
+                    filled: true,
+                    fillColor: Colors.grey[100],
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _passwordController,
+                  obscureText: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return passwordError;
+                    }
+                    return null;
+                  },
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.lock, color: Color(0xFF1A2543)),
+                    hintText: passwordHint,
+                    filled: true,
+                    fillColor: Colors.grey[100],
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _confirmController,
+                  obscureText: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return confirmEmptyError;
+                    }
+                    if (value != _passwordController.text) {
+                      return confirmError;
+                    }
+                    return null;
+                  },
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.lock_outline, color: Color(0xFF1A2543)),
+                    hintText: confirmHint,
+                    filled: true,
+                    fillColor: Colors.grey[100],
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 30),
+                _loading
+                    ? const CircularProgressIndicator(color: Color(0xFF1A2543))
+                    : SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: _register,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: const Color(0xFF1A2543),
+                            minimumSize: const Size(0, 50),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                          child: Text(
+                            buttonText,
+                            style: const TextStyle(fontSize: 18, color: Colors.white),
+                          ),
+                        ),
+                      ),
+                const SizedBox(height: 20),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- wrap the register screen inputs with a `Form` that uses a `GlobalKey` and localized validation messages
- convert the text fields to `TextFormField` widgets with locale-aware validation for name, email, phone, and passwords
- validate the form before invoking the API and show bilingual failure snack bars

## Testing
- not run (Flutter SDK is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d90ceb1350832aa96d69f4a563d177