### PR TITLE
Add Firebase messaging service worker configuration for web

### DIFF
--- a/web/firebase-messaging-sw.js
+++ b/web/firebase-messaging-sw.js
@@ -1,0 +1,14 @@
+importScripts('https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/9.22.2/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: 'AIzaSyBSl6tHzf6x-WQAC4ecuuquoUGtwFfvUn8',
+  appId: '1:641037176066:web:placeholder',
+  messagingSenderId: '641037176066',
+  projectId: 'book-3d7c1',
+  authDomain: 'book-3d7c1.firebaseapp.com',
+  storageBucket: 'book-3d7c1.appspot.com',
+  measurementId: 'G-PLACEHOLDER',
+});
+
+firebase.messaging();


### PR DESCRIPTION
## Summary
- add a Firebase Messaging service worker script for the web build
- initialize Firebase using the existing web configuration and retain the messaging service reference

## Testing
- flutter build web *(fails: Flutter SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da24ab5dc4832a829aa09220d335e7