### PR TITLE
Initialize Firebase in background handler

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,13 +1,18 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../firebase_options.dart';
 import '../services/api_service.dart';
 import '../models/order.dart';
 
 @pragma('vm:entry-point')
 Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  }
   await NotificationService().handleBackgroundMessage(message);
 }
 


### PR DESCRIPTION
## Summary
- add the firebase core and generated options imports to the notification service
- ensure the background message handler initializes firebase before handling messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da2c0447f8832a99943ac78c05bec0