### PR TITLE
Handle FCM token refresh updates

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -35,6 +35,7 @@ class NotificationService {
   static const String _notificationsListKey = 'notifications';
   static const String _unreadCountKey = 'unread_notifications';
   static StreamSubscription<RemoteMessage>? _foregroundSubscription;
+  StreamSubscription<String>? _tokenRefreshSubscription;
 
   /// Clears stored notification-related data from [SharedPreferences].
   static Future<void> clearStoredData() async {
@@ -72,6 +73,9 @@ class NotificationService {
 
     FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
 
+    _tokenRefreshSubscription ??=
+        _fcm.onTokenRefresh.listen((token) => unawaited(_handleTokenRefresh(token)));
+
     if (notificationsEnabled) {
       _startForegroundListener();
     } else {
@@ -91,6 +95,8 @@ class NotificationService {
 
   Future<void> logoutCleanup({String? email}) async {
     await _stopForegroundListener();
+    await _tokenRefreshSubscription?.cancel();
+    _tokenRefreshSubscription = null;
     await clearStoredData();
 
     final prefs = await SharedPreferences.getInstance();
@@ -120,10 +126,24 @@ class NotificationService {
     if (settings.authorizationStatus == AuthorizationStatus.authorized) {
       final token = await _fcm.getToken();
       if (token != null) {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setString('fcm_token', token);
-        print('FCM Token: $token');
+        await _handleTokenRefresh(token);
       }
+    }
+  }
+
+  Future<void> _handleTokenRefresh(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('fcm_token', token);
+    final email = prefs.getString('user_email');
+
+    if (email == null || email.isEmpty) {
+      return;
+    }
+
+    try {
+      await _apiService.updateFcmToken(email, token);
+    } catch (e) {
+      print('Error updating FCM token on refresh: $e');
     }
   }
 


### PR DESCRIPTION
## Summary
- add an FCM token refresh listener that stores tokens and updates the backend
- reuse the token refresh handler during permission requests and cancel the listener on logout

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da2c7fda30832abefb98a23b156b1c