### PR TITLE
Add cash checkout flow for eligible carts

### DIFF
--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -5,6 +5,7 @@ import '../providers/cart_provider.dart';
 import '../providers/locale_provider.dart';
 import '../utils.dart';
 import '../models/product.dart'; // Make sure Product model is imported
+import 'checkout_screen.dart';
 
 class CartScreen extends StatelessWidget {
   const CartScreen({Key? key}) : super(key: key);
@@ -117,7 +118,7 @@ class CartScreen extends StatelessWidget {
                     ),
                   ),
                 ),
-                _buildCheckoutButton(context, checkoutText),
+                _buildCheckoutButton(context, checkoutText, cartProvider),
               ],
             ),
           ],
@@ -206,7 +207,8 @@ class CartScreen extends StatelessWidget {
   // Removed the _buildCartSummary method as it's no longer needed
 
   // --- Checkout Button ---
-  Widget _buildCheckoutButton(BuildContext context, String label) {
+  Widget _buildCheckoutButton(
+      BuildContext context, String label, CartProvider cartProvider) {
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
       width: double.infinity,
@@ -220,7 +222,34 @@ class CartScreen extends StatelessWidget {
           shadowColor: Colors.black.withOpacity(0.2),
         ),
         onPressed: () {
-          Navigator.pushNamed(context, '/installment-options');
+          final items = cartProvider.items;
+          if (items.isEmpty) {
+            return;
+          }
+
+          final isCashOrder =
+              items.every((item) => item.product.shortDescription.trim().isEmpty);
+
+          if (isCashOrder) {
+            final totalAmount = cartProvider.totalAmount;
+
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => CheckoutScreen(
+                  isCashOrder: true,
+                  totalPrice: totalAmount,
+                  downPayment: totalAmount,
+                  remainingAmount: 0,
+                  monthlyPayment: 0,
+                  numberOfInstallments: 0,
+                  isCustomPlan: false,
+                ),
+              ),
+            );
+          } else {
+            Navigator.pushNamed(context, '/installment-options');
+          }
         },
         child: Text(
           label,

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -198,8 +198,10 @@ class ApiService {
     required bool isNewCustomer,
     String? customerNote,
   }) async {
+    final isCashOrder = installmentType == 'cash';
+
     String orderNotes = "Installment Type: $installmentType\n";
-    if (customInstallment != null) {
+    if (!isCashOrder && customInstallment != null) {
       orderNotes += """
 Down Payment: ${customInstallment['downPayment']} QAR
 Remaining Amount: ${customInstallment['remainingAmount']} QAR
@@ -211,6 +213,13 @@ Monthly Installments (4 months): ${customInstallment['monthlyPayment']} QAR each
       orderNotes += "\n\nCustomer Note: $customerNote";
     }
 
+    final metaData = [
+      {'key': 'installment_type', 'value': installmentType},
+      {'key': 'is_new_customer', 'value': isNewCustomer},
+      if (!isCashOrder && customInstallment != null)
+        {'key': 'custom_installment', 'value': json.encode(customInstallment)},
+    ];
+
     final orderData = {
       'status': 'pending',
       'customer_note': orderNotes,
@@ -220,12 +229,7 @@ Monthly Installments (4 months): ${customInstallment['monthlyPayment']} QAR each
         'phone': customerPhone,
       },
       'line_items': lineItems,
-      'meta_data': [
-        {'key': 'installment_type', 'value': installmentType},
-        {'key': 'is_new_customer', 'value': isNewCustomer},
-        if (customInstallment != null)
-          {'key': 'custom_installment', 'value': json.encode(customInstallment)},
-      ],
+      'meta_data': metaData,
     };
 
     final response = await http.post(


### PR DESCRIPTION
## Summary
- route cash-eligible carts directly to checkout and pass totals into the screen
- extend the checkout screen to support cash orders and hide installment details when unnecessary
- update the API service to omit installment metadata for cash orders

## Testing
- not run (Flutter/Dart tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dbc7f9a468832ab438824c8879117c