### PR TITLE
Ensure login hydrates missing WooCommerce customer IDs

### DIFF
--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -18,19 +18,25 @@ class UserProvider extends ChangeNotifier {
   bool get isLoggedIn => _user != null;
 
   void setUser(User newUser) async {
-    _user = newUser;
+    final prefs = await SharedPreferences.getInstance();
+    final int? persistedId =
+        newUser.id ?? prefs.getInt('user_id') ?? _user?.id;
+    final userWithId = (persistedId != null && newUser.id != persistedId)
+        ? newUser.copyWith(id: persistedId)
+        : newUser;
+
+    _user = userWithId;
     notifyListeners();
 
-    final prefs = await SharedPreferences.getInstance();
-    if (newUser.id != null) {
-      await prefs.setInt('user_id', newUser.id!);
+    if (userWithId.id != null) {
+      await prefs.setInt('user_id', userWithId.id!);
     } else {
       await prefs.remove('user_id');
     }
-    await prefs.setString('user_token', newUser.token);
-    await prefs.setString('user_name', newUser.username);
-    await prefs.setString('user_email', newUser.email);
-    await prefs.setString('user_phone', newUser.phone); // ✅ احفظ رقم الهاتف
+    await prefs.setString('user_token', userWithId.token);
+    await prefs.setString('user_name', userWithId.username);
+    await prefs.setString('user_email', userWithId.email);
+    await prefs.setString('user_phone', userWithId.phone); // ✅ احفظ رقم الهاتف
   }
 
   Future<void> loadUserFromPrefs() async {
@@ -43,13 +49,14 @@ class UserProvider extends ChangeNotifier {
 
 
     if (token != null && username != null && email != null) {
-      setUser(User(
+      final restoredUser = User(
         id: userId,
         token: token,
         username: username,
         email: email,
         phone: phone ?? '',
-      ));
+      );
+      setUser(restoredUser);
     }
   }
   Future<void> logout() async {

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -356,6 +356,43 @@ Monthly Installments (4 months): ${customInstallment['monthlyPayment']} QAR each
     }
   }
 
+  Future<int?> fetchCustomerIdByEmail(String email) async {
+    final response = await http.get(
+      _uri(
+        '/customers',
+        queryParameters: {
+          'email': email,
+          'per_page': '1',
+        },
+      ),
+      headers: _defaultHeaders(),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Failed to fetch customer by email: ${response.statusCode} ${response.body}',
+      );
+    }
+
+    final data = jsonDecode(response.body);
+    final customers = _ensureList(data, fallbackKey: 'customers');
+    if (customers.isEmpty) {
+      return null;
+    }
+
+    final dynamic firstCustomer = customers.first;
+    if (firstCustomer is! Map) {
+      throw Exception('Unexpected customer payload: $firstCustomer');
+    }
+
+    final customer = Map<String, dynamic>.from(firstCustomer as Map);
+    final dynamic idSource = customer['id'] ?? customer['ID'];
+    if (idSource is int) return idSource;
+    if (idSource is String) return int.tryParse(idSource);
+    if (idSource is double) return idSource.toInt();
+    return null;
+  }
+
   Future<bool> updateFcmToken(String email, String token) async {
     try {
       final response = await http.post(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -25,17 +25,26 @@ class AuthService {
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
       final prefs = await SharedPreferences.getInstance();
-      final user = User.fromJson(data);
+      var user = User.fromJson(data);
+
+      String? email = data['email'] ?? data['user_email'];
+      final String? normalizedEmail =
+          email ?? (user.email.isNotEmpty ? user.email : null);
+
+      final bool isIdMissing = user.id == null || user.id == 0;
+      if (isIdMissing && normalizedEmail != null) {
+        final fetchedId =
+            await ApiService().fetchCustomerIdByEmail(normalizedEmail);
+        if (fetchedId != null) {
+          user = user.copyWith(id: fetchedId);
+        }
+      }
 
       if (user.id != null) {
         await prefs.setInt('user_id', user.id!);
       } else {
         await prefs.remove('user_id');
       }
-
-      String? email = data['email'] ?? data['user_email'];
-      final String? normalizedEmail =
-          email ?? (user.email.isNotEmpty ? user.email : null);
 
       // Get and update FCM token
       String? fcmToken = await prefs.getString('fcm_token');


### PR DESCRIPTION
## Summary
- fetch the WooCommerce customer record when a JWT login lacks an id and persist it
- expose a helper on ApiService to look up customer ids by email
- preserve previously stored user identifiers when hydrating the UserProvider from preferences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3535974b8832a8125aaaa34aa6f5d