### PR TITLE
Handle delete account failures

### DIFF
--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -75,23 +75,31 @@ class UserProvider extends ChangeNotifier {
     _user = null;
     notifyListeners();
   }
-  Future<void> deleteAccount() async {
+  Future<bool> deleteAccount() async {
     final prefs = await SharedPreferences.getInstance();
     final userId = prefs.getInt('user_id');
 
     if (userId == null) {
       debugPrint('No user ID found. Cannot delete.');
-      return;
+      return false;
     }
 
-    final success = await ApiService().deleteAccount(userId);
-    if (!success) {
-      debugPrint('خطأ أثناء حذف الحساب');
-    }
+    try {
+      final success = await ApiService().deleteAccount(userId);
+      if (!success) {
+        debugPrint('Failed to delete account from API.');
+        return false;
+      }
 
-    await prefs.clear();
-    _user = null;
-    notifyListeners();
+      await prefs.clear();
+      _user = null;
+      notifyListeners();
+      return true;
+    } catch (error, stackTrace) {
+      debugPrint('Exception while deleting account: $error');
+      debugPrint(stackTrace.toString());
+      rethrow;
+    }
   }
 
   Future<void> updateUser({

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/user_provider.dart';
@@ -466,15 +467,45 @@ class ProfileScreen extends StatelessWidget {
     );
 
     if (confirm == true) {
-      await userProvider.deleteAccount();
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(isArabic ? 'تم حذف الحساب بنجاح.' : 'Account deleted successfully.', style: const TextStyle(color: Colors.white)),
-          backgroundColor: _accentColor,
-        ),
-      );
-      Navigator.pushReplacementNamed(context, '/login'); // أو إلى الشاشة الرئيسية كزائر
+      try {
+        final success = await userProvider.deleteAccount();
+        if (!context.mounted) return;
+
+        if (success) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                isArabic ? 'تم حذف الحساب بنجاح.' : 'Account deleted successfully.',
+                style: const TextStyle(color: Colors.white),
+              ),
+              backgroundColor: _accentColor,
+            ),
+          );
+          Navigator.pushReplacementNamed(context, '/login'); // أو إلى الشاشة الرئيسية كزائر
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                isArabic ? 'تعذر حذف الحساب. حاول مرة أخرى لاحقًا.' : 'Unable to delete the account. Please try again later.',
+                style: const TextStyle(color: Colors.white),
+              ),
+              backgroundColor: Colors.red.shade600,
+            ),
+          );
+        }
+      } catch (error) {
+        debugPrint('Error while deleting account: $error');
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              isArabic ? 'حدث خطأ غير متوقع أثناء حذف الحساب.' : 'An unexpected error occurred while deleting the account.',
+              style: const TextStyle(color: Colors.white),
+            ),
+            backgroundColor: Colors.red.shade600,
+          ),
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- return a success flag from the user provider's deleteAccount flow and log unexpected errors
- update the profile screen to surface errors when deletion fails and only clear session state on success

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f358b6e450832ab4a929d8aa92ceb0