### PR TITLE
Guard dotenv loading for release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ each build must provide a WooCommerce consumer key and secret.
 ## Environment configuration
 
 The application reads credentials from a `.env` file via
-[`flutter_dotenv`](https://pub.dev/packages/flutter_dotenv). Copy the example
-file and fill in the values provided by the WooCommerce backend team:
+[`flutter_dotenv`](https://pub.dev/packages/flutter_dotenv) during local
+development. Copy the example file and fill in the values provided by the
+WooCommerce backend team:
 
 ```bash
 cp .env.example .env
@@ -21,7 +22,9 @@ WOO_CONSUMER_KEY=ck_live_value
 WOO_CONSUMER_SECRET=cs_live_value
 ```
 
-The file is ignored by Git, ensuring secrets remain local to your machine.
+The file is ignored by Git, ensuring secrets remain local to your machine. It is
+only used in debug/dev builds—the `.env` file is not bundled into release
+artifacts.
 
 ### Alternative: CI/CD environments
 
@@ -37,6 +40,25 @@ flutter run \
 
 When using CI, ensure the job exports these flags for any `flutter run`,
 `flutter test`, or `flutter build` invocation so HTTP requests are authorized.
+
+### Release builds
+
+Release builds **must** provide the WooCommerce credentials with `--dart-define`
+flags so [`AppConfig`](lib/constants/app_config.dart) can read them at runtime.
+Example commands:
+
+```bash
+flutter build apk --release \
+  --dart-define=WOO_CONSUMER_KEY=ck_live_value \
+  --dart-define=WOO_CONSUMER_SECRET=cs_live_value
+
+flutter build ios --release \
+  --dart-define=WOO_CONSUMER_KEY=ck_live_value \
+  --dart-define=WOO_CONSUMER_SECRET=cs_live_value
+```
+
+Replace the values with production credentials supplied by the WooCommerce
+backend team.
 
 ## Running the app locally
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,9 @@ import 'firebase_options.dart';
 import 'theme.dart';
 
 Future<void> _loadEnvironment() async {
+  if (kReleaseMode) {
+    return;
+  }
   try {
     await dotenv.load(fileName: '.env');
   } on FlutterError catch (error) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,7 +77,6 @@ flutter:
     - assets/images/logo_login.png
     - assets/sounds/click.mp3
     - assets/sounds/delete.mp3
-    - .env
 
 
   fonts:


### PR DESCRIPTION
## Summary
- remove the `.env` file from the Flutter asset bundle
- guard the runtime dotenv loading so release builds fall back to `--dart-define`
- document the required `--dart-define` flags for release builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f36f6a12d0832aa6cb29816e9dc4e8