### PR TITLE
Clean up Android manifest permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
 


### PR DESCRIPTION
## Summary
- remove the duplicate INTERNET permission declaration from the Android manifest
- drop the unused WAKE_LOCK permission to avoid requesting unnecessary capabilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f36fdc3ad8832ab1a295ea413782d6