### PR TITLE
Handle empty email when loading orders

### DIFF
--- a/lib/screens/orders_screen.dart
+++ b/lib/screens/orders_screen.dart
@@ -50,6 +50,11 @@ class _OrdersScreenState extends State<OrdersScreen> with TickerProviderStateMix
   Future<List<Order>> _loadOrdersAndTrackChanges() async {
     try {
       final userEmail = Provider.of<UserProvider>(context, listen: false).user?.email ?? "";
+
+      if (userEmail.isEmpty) {
+        return <Order>[];
+      }
+
       final orders = await ApiService().getOrders(userEmail: userEmail);
       await _trackOrderStatusChanges(orders);
       return orders;


### PR DESCRIPTION
## Summary
- ensure order loading exits early when no user email is available to avoid tracking

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3746836e0832a92834109ca99e9b7