### PR TITLE
Guard order status tracking against unmounted state

### DIFF
--- a/lib/screens/orders_screen.dart
+++ b/lib/screens/orders_screen.dart
@@ -118,11 +118,19 @@ class _OrdersScreenState extends State<OrdersScreen> with TickerProviderStateMix
   }
 
   Future<void> _trackOrderStatusChanges(List<Order> orders) async {
+    if (!mounted) {
+      return;
+    }
+
     final prefs = await SharedPreferences.getInstance();
     final storedStatuses = prefs.getString('order_statuses') ?? '{}';
     final Map<String, String> oldStatuses = Map<String, String>.from(json.decode(storedStatuses));
     final notifications = prefs.getStringList('notifications') ?? [];
     int unreadCount = prefs.getInt('unread_notifications') ?? 0;
+
+    if (!mounted) {
+      return;
+    }
 
     final langCode = Localizations.localeOf(context).languageCode;
 


### PR DESCRIPTION
## Summary
- ensure `_trackOrderStatusChanges` exits early when the state is no longer mounted
- avoid calling `Localizations.localeOf` after the widget has been disposed to prevent exceptions

## Testing
- flutter test *(fails: flutter command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f374d70a2c832a851d5b282ff653cd