### PR TITLE
Refine notification listening strategy

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -34,7 +34,7 @@ class _HomeScreenState extends State<HomeScreen>
   final ValueNotifier<int> _notificationCount = ValueNotifier<int>(0);
   late final LocaleProvider _localeProvider;
   late final UserProvider _userProvider;
-  StreamSubscription<void>? _notificationSubscription;
+  StreamSubscription<int>? _notificationSubscription;
   final List<int> topRequestedProductIdsAr = [12226, 12261, 12245, 12762];
   final List<int> topRequestedProductIdsEn = [12902, 13310, 13325, 12835];
 
@@ -137,14 +137,25 @@ class _HomeScreenState extends State<HomeScreen>
       return;
     }
 
-    if (_notificationSubscription != null) {
+    final service = NotificationService();
+    final notificationsEnabled = await service.getNotificationsEnabled();
+    if (!notificationsEnabled) {
+      _cancelNotificationSubscription();
       return;
     }
 
-    final count = await NotificationService().getUnreadCount();
+    if (_notificationSubscription != null) {
+      await service.refreshUnreadCount();
+      return;
+    }
+
+    final count = await service.getUnreadCount();
     if (!mounted) return;
     _notificationCount.value = count;
-    _notificationSubscription = _startNotificationPolling();
+    if (_notificationSubscription == null) {
+      _notificationSubscription = _startNotificationListener(service);
+    }
+    await service.refreshUnreadCount();
   }
 
   void _cancelNotificationSubscription({bool resetCount = true}) {
@@ -155,28 +166,11 @@ class _HomeScreenState extends State<HomeScreen>
     }
   }
 
-  StreamSubscription<void>? _startNotificationPolling() {
-    final userEmail = _userProvider.user?.email;
-
-    if (userEmail == null || userEmail.isEmpty) {
-      return null;
-    }
-
-    return Stream<void>.periodic(const Duration(seconds: 15))
-        .asyncMap((_) async {
-      final currentUserEmail = _userProvider.user?.email;
-      if (currentUserEmail == null || currentUserEmail.isEmpty) {
-        return;
-      }
-
-      await NotificationService().checkOrderStatusUpdates(
-        userEmail: currentUserEmail,
-        langCode: _localeProvider.locale.languageCode,
-      );
-      final count = await NotificationService().getUnreadCount();
+  StreamSubscription<int>? _startNotificationListener(NotificationService service) {
+    return service.unreadCountStream.listen((count) {
       if (!mounted) return;
       _notificationCount.value = count;
-    }).listen((_) {});
+    });
   }
 
   void _loadData(String language) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -31,6 +31,7 @@ class NotificationService {
   final FlutterLocalNotificationsPlugin _localNotifications;
   final ApiService _apiService;
   final Future<void> Function()? _deleteTokenOverride;
+  static final StreamController<int> _unreadCountController = StreamController<int>.broadcast();
   static const String _notificationsEnabledKey = 'notifications_enabled';
   static const String _notificationsListKey = 'notifications';
   static const String _unreadCountKey = 'unread_notifications';
@@ -207,7 +208,9 @@ class NotificationService {
 
     notifications.insert(0, jsonEncode(notification));
     await prefs.setStringList(_notificationsListKey, notifications);
-    await prefs.setInt(_unreadCountKey, unreadCount + 1);
+    final updatedCount = unreadCount + 1;
+    await prefs.setInt(_unreadCountKey, updatedCount);
+    _unreadCountController.add(updatedCount);
   }
 
   Future<void> setNotificationsEnabled(bool enabled) async {
@@ -237,6 +240,13 @@ class NotificationService {
     return prefs.getInt(_unreadCountKey) ?? 0;
   }
 
+  Stream<int> get unreadCountStream => _unreadCountController.stream;
+
+  Future<void> refreshUnreadCount() async {
+    final count = await getUnreadCount();
+    _unreadCountController.add(count);
+  }
+
   Future<void> markAllAsRead() async {
     final prefs = await SharedPreferences.getInstance();
     final notifications = prefs.getStringList(_notificationsListKey) ?? [];
@@ -249,6 +259,7 @@ class NotificationService {
 
     await prefs.setStringList(_notificationsListKey, updated);
     await prefs.setInt(_unreadCountKey, 0);
+    _unreadCountController.add(0);
   }
 
   // 🆕 تتبع تغييرات الطلبات يدويًا
@@ -302,6 +313,7 @@ class NotificationService {
     await prefs.setStringList(_notificationsListKey, notifications);
     await prefs.setInt(_unreadCountKey, unreadCount);
     await prefs.setString('order_statuses', json.encode(oldStatuses));
+    _unreadCountController.add(unreadCount);
   }
 
   String _translateStatus(String status, String langCode) {


### PR DESCRIPTION
## Summary
- replace HomeScreen's periodic notification polling with a listener that reacts to unread count updates
- expose a broadcast unread-count stream in NotificationService and emit updates whenever the counter changes

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f375694b54832ab56563f10ceee724