### PR TITLE
Hide empty-category product notices

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1477,37 +1477,7 @@ class _HomeScreenState extends State<HomeScreen>
               final fetched = snapshot.data ?? const <Product>[];
               final cashProducts = fetched.where((p) => p.shortDescription.trim().isEmpty).toList();
               if (cashProducts.isEmpty) {
-                return Container(
-                  height: 150,
-                  margin: const EdgeInsets.symmetric(horizontal: 16),
-                  decoration: BoxDecoration(
-                    color: Colors.grey.withOpacity(0.05),
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(
-                      color: Colors.grey.withOpacity(0.2),
-                    ),
-                  ),
-                  child: Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.inventory_2_outlined,
-                          color: Colors.grey.withOpacity(0.5),
-                          size: 32,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          noProductsForCategoryText,
-                          style: TextStyle(
-                            color: Colors.grey.withOpacity(0.7),
-                            fontSize: 14,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                );
+                return const SizedBox.shrink();
               }
               final products = cashProducts;
               return SizedBox(

--- a/lib/screens/installment_store_screen.dart
+++ b/lib/screens/installment_store_screen.dart
@@ -328,21 +328,7 @@ class _InstallmentStoreScreenState extends State<InstallmentStoreScreen>
               final fetched = snapshot.data ?? const <Product>[];
               final installmentProducts = fetched.where((p) => p.shortDescription.trim().isNotEmpty).toList();
               if (installmentProducts.isEmpty) {
-                return Container(
-                  height: 150,
-                  margin: const EdgeInsets.symmetric(horizontal: 16),
-                  decoration: BoxDecoration(
-                    color: Colors.grey.withOpacity(0.05),
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(color: Colors.grey.withOpacity(0.2)),
-                  ),
-                  child: Center(
-                    child: Text(
-                      noProductsText,
-                      style: TextStyle(color: Colors.grey.withOpacity(0.7), fontSize: 14),
-                    ),
-                  ),
-                );
+                return const SizedBox.shrink();
               }
 
               return SizedBox(


### PR DESCRIPTION
## Summary
- stop rendering the "no products" notice in the cash-only category sections
- hide the empty-state notice for installment category sections so the banner is not shown

## Testing
- flutter analyze *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3766f3f14832ab9b82f70719fba72