### PR TITLE
Hide category sections without products

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1089,24 +1089,23 @@ class _HomeScreenState extends State<HomeScreen>
           children: categories
               .map(
                 (category) => TweenAnimationBuilder(
-              duration: const Duration(milliseconds: 600),
-              tween: Tween<double>(begin: 0, end: 1),
-              builder: (context, double value, child) {
-                return Transform.translate(
-                  offset: Offset(0, 30 * (1 - value)),
-                  child: Opacity(
-                    opacity: value,
-                    child: _buildCategorySection(
-                      category,
-                      moreLabel: moreLabel,
-                      noProductsForCategoryText: noProductsForCategoryText,
-                      currentLanguage: currentLanguage,
-                    ),
-                  ),
-                );
-              },
-            ),
-          )
+                  duration: const Duration(milliseconds: 600),
+                  tween: Tween<double>(begin: 0, end: 1),
+                  builder: (context, double value, child) {
+                    return Transform.translate(
+                      offset: Offset(0, 30 * (1 - value)),
+                      child: Opacity(
+                        opacity: value,
+                        child: _buildCategorySection(
+                          category,
+                          moreLabel: moreLabel,
+                          currentLanguage: currentLanguage,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              )
               .toList(),
         );
       },
@@ -1350,40 +1349,40 @@ class _HomeScreenState extends State<HomeScreen>
   }
 
   Widget _buildCategorySection(Category category,
-      {required String currentLanguage,
-        required String moreLabel,
-        required String noProductsForCategoryText}) {
-    return Container(
-      margin: const EdgeInsets.only(bottom: 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Container(
+      {required String currentLanguage, required String moreLabel}) {
+    return FutureBuilder<List<Product>>(
+      future: apiService.getProducts(
+        categoryId: category.id,
+        language: currentLanguage,
+        perPage: 10,
+      ),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return const SizedBox.shrink();
+        }
+
+        final isWaiting = snapshot.connectionState == ConnectionState.waiting;
+        final fetched = snapshot.data ?? const <Product>[];
+        final cashProducts =
+            fetched.where((p) => p.shortDescription.trim().isEmpty).toList();
+
+        if (!isWaiting && cashProducts.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        Widget buildHeader() {
+          return Container(
             margin: const EdgeInsets.symmetric(horizontal: 8),
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 15),
             decoration: BoxDecoration(
               color: Colors.transparent,
               borderRadius: BorderRadius.circular(8),
-
             ),
-
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Row(
                   children: [
-                    // Container(
-                    //   padding: const EdgeInsets.all(8),
-                    //   decoration: BoxDecoration(
-                    //     color: const Color(0xFF6FE0DA).withOpacity(0.2),
-                    //     borderRadius: BorderRadius.circular(8),
-                    //   ),
-                    //   child: const Icon(
-                    //     Icons.inventory_2_rounded,
-                    //     color: Color(0xFF1A2543),
-                    //     size: 20,
-                    //   ),
-                    // ),
                     const SizedBox(width: 12),
                     Text(
                       category.name,
@@ -1412,7 +1411,8 @@ class _HomeScreenState extends State<HomeScreen>
                     },
                     borderRadius: BorderRadius.circular(20),
                     child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 6),
                       decoration: BoxDecoration(
                         color: const Color(0xFF6FE0DA).withOpacity(0.1),
                         borderRadius: BorderRadius.circular(20),
@@ -1445,71 +1445,78 @@ class _HomeScreenState extends State<HomeScreen>
                 ),
               ],
             ),
-          ),
-          const SizedBox(height: 12),
-          FutureBuilder<List<Product>>(
-            future: apiService.getProducts(categoryId: category.id, language: currentLanguage, perPage: 10),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return SizedBox(
-                  height: 290,
-                  child: ListView.builder(
-                    scrollDirection: Axis.horizontal,
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    itemCount: 4,
-                    itemBuilder: (context, index) {
-                      return Container(
-                        width: 160,
-                        margin: const EdgeInsets.symmetric(horizontal: 4),
-                        decoration: BoxDecoration(
-                          color: Colors.grey.withOpacity(0.1),
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: const Center(
-                          child: CircularProgressIndicator.adaptive(),
-                        ),
-                      );
-                    },
+          );
+        }
+
+        Widget buildSkeleton() {
+          return SizedBox(
+            height: 290,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              itemCount: 4,
+              itemBuilder: (context, index) {
+                return Container(
+                  width: 160,
+                  margin: const EdgeInsets.symmetric(horizontal: 4),
+                  decoration: BoxDecoration(
+                    color: Colors.grey.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: const Center(
+                    child: CircularProgressIndicator.adaptive(),
                   ),
                 );
-              }
-              // Cash-only: filter fetched products to cash items
-              final fetched = snapshot.data ?? const <Product>[];
-              final cashProducts = fetched.where((p) => p.shortDescription.trim().isEmpty).toList();
-              if (cashProducts.isEmpty) {
-                return const SizedBox.shrink();
-              }
-              final products = cashProducts;
-              return SizedBox(
-                height: 290,
-                child: ListView.builder(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  itemCount: products.length,
-                  itemBuilder: (context, index) {
-                    return TweenAnimationBuilder(
-                      duration: Duration(milliseconds: 300 + (index * 50)),
-                      tween: Tween<double>(begin: 0, end: 1),
-                      builder: (context, double value, child) {
-                        return Transform.translate(
-                          offset: Offset(0, 15 * (1 - value)),
-                          child: Opacity(
-                            opacity: value,
-                            child: SizedBox(
-                              width: 160,
-                              child: ProductCard(product: products[index]),
-                            ),
-                          ),
-                        );
-                      },
+              },
+            ),
+          );
+        }
+
+        Widget buildProducts(List<Product> products) {
+          return SizedBox(
+            height: 290,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              itemCount: products.length,
+              itemBuilder: (context, index) {
+                return TweenAnimationBuilder(
+                  duration: Duration(milliseconds: 300 + (index * 50)),
+                  tween: Tween<double>(begin: 0, end: 1),
+                  builder: (context, double value, child) {
+                    return Transform.translate(
+                      offset: Offset(0, 15 * (1 - value)),
+                      child: Opacity(
+                        opacity: value,
+                        child: SizedBox(
+                          width: 160,
+                          child: ProductCard(product: products[index]),
+                        ),
+                      ),
                     );
                   },
-                ),
-              );
-            },
+                );
+              },
+            ),
+          );
+        }
+
+        final body = isWaiting
+            ? buildSkeleton()
+            : buildProducts(cashProducts);
+
+        return Container(
+          margin: const EdgeInsets.only(bottom: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              buildHeader(),
+              const SizedBox(height: 12),
+              body,
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 

--- a/lib/screens/installment_store_screen.dart
+++ b/lib/screens/installment_store_screen.dart
@@ -256,15 +256,33 @@ class _InstallmentStoreScreenState extends State<InstallmentStoreScreen>
     );
   }
 
-  Widget _buildSingleCategorySection(Category category, String language, bool isArabic) {
+  Widget _buildSingleCategorySection(
+      Category category, String language, bool isArabic) {
     final moreLabel = isArabic ? 'المزيد' : 'More';
-    final noProductsText = isArabic ? 'لا توجد منتجات لهذا التصنيف' : 'No products for this category';
-    return Container(
-      margin: const EdgeInsets.only(bottom: 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
+
+    return FutureBuilder<List<Product>>(
+      future: _api.getProducts(
+        categoryId: category.id,
+        language: language,
+        perPage: 10,
+      ),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return const SizedBox.shrink();
+        }
+
+        final isWaiting = snapshot.connectionState == ConnectionState.waiting;
+        final fetched = snapshot.data ?? const <Product>[];
+        final installmentProducts = fetched
+            .where((p) => p.shortDescription.trim().isNotEmpty)
+            .toList();
+
+        if (!isWaiting && installmentProducts.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        Widget buildHeader() {
+          return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -294,63 +312,79 @@ class _InstallmentStoreScreenState extends State<InstallmentStoreScreen>
                     );
                     HapticFeedback.lightImpact();
                   },
-                  icon: const Icon(Icons.arrow_forward_ios, size: 14, color: Color(0xFF6FE0DA)),
+                  icon: const Icon(
+                    Icons.arrow_forward_ios,
+                    size: 14,
+                    color: Color(0xFF6FE0DA),
+                  ),
                   label: Text(
                     moreLabel,
-                    style: const TextStyle(color: Color(0xFF6FE0DA), fontSize: 12),
+                    style:
+                        const TextStyle(color: Color(0xFF6FE0DA), fontSize: 12),
                   ),
                 ),
               ],
             ),
-          ),
-          FutureBuilder<List<Product>>(
-            future: _api.getProducts(categoryId: category.id, language: language, perPage: 10),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return SizedBox(
-                  height: 290,
-                  child: ListView.builder(
-                    scrollDirection: Axis.horizontal,
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    itemCount: 4,
-                    itemBuilder: (context, index) => Container(
-                      width: 160,
-                      margin: const EdgeInsets.symmetric(horizontal: 4),
-                      decoration: BoxDecoration(
-                        color: Colors.grey.withOpacity(0.1),
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: const Center(child: CircularProgressIndicator.adaptive()),
-                    ),
-                  ),
-                );
-              }
-              final fetched = snapshot.data ?? const <Product>[];
-              final installmentProducts = fetched.where((p) => p.shortDescription.trim().isNotEmpty).toList();
-              if (installmentProducts.isEmpty) {
-                return const SizedBox.shrink();
-              }
+          );
+        }
 
-              return SizedBox(
-                height: 290,
-                child: ListView.builder(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  itemCount: installmentProducts.length,
-                  itemBuilder: (context, index) {
-                    final product = installmentProducts[index];
-                    return Container(
-                      width: 160,
-                      margin: const EdgeInsets.symmetric(horizontal: 4),
-                      child: ProductCard(product: product),
-                    );
-                  },
+        Widget buildSkeleton() {
+          return SizedBox(
+            height: 290,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              itemCount: 4,
+              itemBuilder: (context, index) => Container(
+                width: 160,
+                margin: const EdgeInsets.symmetric(horizontal: 4),
+                decoration: BoxDecoration(
+                  color: Colors.grey.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(12),
                 ),
-              );
-            },
+                child: const Center(
+                  child: CircularProgressIndicator.adaptive(),
+                ),
+              ),
+            ),
+          );
+        }
+
+        Widget buildProducts(List<Product> products) {
+          return SizedBox(
+            height: 290,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              itemCount: products.length,
+              itemBuilder: (context, index) {
+                final product = products[index];
+                return Container(
+                  width: 160,
+                  margin: const EdgeInsets.symmetric(horizontal: 4),
+                  child: ProductCard(product: product),
+                );
+              },
+            ),
+          );
+        }
+
+        final body = isWaiting
+            ? buildSkeleton()
+            : buildProducts(installmentProducts);
+
+        return Container(
+          margin: const EdgeInsets.only(bottom: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              buildHeader(),
+              const SizedBox(height: 12),
+              body,
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- move cash category headers inside their product futures and shrink sections when no items arrive
- apply the same shrink logic to installment categories and remove unused text handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f378c62800832aaa7f4be277eecb3c