### PR TITLE
Skip WooCommerce basic auth headers on web

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -25,8 +26,11 @@ class ApiService {
   }) {
     final headers = <String, String>{
       'Accept': 'application/json',
-      ...AppConfig.wooCommerceAuthHeaders,
     };
+
+    if (!kIsWeb) {
+      headers.addAll(AppConfig.wooCommerceAuthHeaders);
+    }
 
     if (includeJson) {
       headers['Content-Type'] = 'application/json';


### PR DESCRIPTION
## Summary
- import kIsWeb and avoid adding WooCommerce basic auth headers for web builds
- keep JSON content-type handling and existing REST configuration intact

## Testing
- flutter build web *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4ad7bb4d4832a8a3ce56855ee54c2