### PR TITLE
Fix category import conflict and map casting

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -65,6 +65,16 @@ class ApiService {
     throw Exception('Unexpected response format from backend: $payload');
   }
 
+  Map<String, dynamic> _ensureMap(dynamic payload, String context) {
+    if (payload is Map<String, dynamic>) {
+      return payload;
+    }
+    if (payload is Map) {
+      return Map<String, dynamic>.from(payload);
+    }
+    throw Exception('Unexpected $context payload: $payload');
+  }
+
   // جلب قائمة المنتجات مع دعم اللغة وفلترة السعر
   Future<List<Product>> getProducts({
     int? categoryId,
@@ -92,7 +102,9 @@ class ApiService {
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
       final productsJson = _ensureList(data, fallbackKey: 'products');
-      return productsJson.map((item) => Product.fromJson(item)).toList();
+      return productsJson
+          .map((item) => Product.fromJson(_ensureMap(item, 'product')))
+          .toList();
     } else {
       throw Exception("Failed to load products: ${response.body}");
     }
@@ -111,7 +123,9 @@ class ApiService {
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
       final categoriesJson = _ensureList(data, fallbackKey: 'categories');
-      return categoriesJson.map((item) => Category.fromJson(item)).toList();
+      return categoriesJson
+          .map((item) => Category.fromJson(_ensureMap(item, 'category')))
+          .toList();
     } else {
       throw Exception("Failed to load categories: ${response.body}");
     }
@@ -142,7 +156,7 @@ class ApiService {
         final productsJson = _ensureList(data, fallbackKey: 'products');
 
         return productsJson
-            .map((item) => Product.fromJson(item as Map<String, dynamic>))
+            .map((item) => Product.fromJson(_ensureMap(item, 'product')))
             .toList();
       }
 
@@ -272,7 +286,7 @@ Monthly Installments (4 months): ${customInstallment['monthlyPayment']} QAR each
       final data = jsonDecode(response.body);
       final ordersJson = _ensureList(data, fallbackKey: 'orders');
       final orders = ordersJson
-          .map((item) => Order.fromJson(item as Map<String, dynamic>))
+          .map((item) => Order.fromJson(_ensureMap(item, 'order')))
           .toList();
 
       return orders


### PR DESCRIPTION
## Summary
- limit the flutter foundation import to kIsWeb to avoid the Category symbol conflict
- add a helper to safely coerce dynamic JSON payloads into Map<String, dynamic>
- reuse the helper when parsing products, categories, and orders to ensure type safety

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4aea18bd8832aab88bbff3e7f03be