### PR TITLE
Handle missing dotenv configuration fallback

### DIFF
--- a/lib/constants/app_config.dart
+++ b/lib/constants/app_config.dart
@@ -24,9 +24,11 @@ class AppConfig {
   /// and fall back to a `--dart-define` flag so CI can inject secrets without
   /// creating files on disk.
   static String get consumerKey {
-    final envValue = dotenv.env['WOO_CONSUMER_KEY']?.trim();
-    if (envValue != null && envValue.isNotEmpty) {
-      return envValue;
+    if (dotenv.isInitialized) {
+      final envValue = dotenv.env['WOO_CONSUMER_KEY']?.trim();
+      if (envValue != null && envValue.isNotEmpty) {
+        return envValue;
+      }
     }
     return _consumerKeyFromDartDefine;
   }
@@ -37,9 +39,11 @@ class AppConfig {
   /// and fall back to a `--dart-define` flag so CI can inject secrets without
   /// creating files on disk.
   static String get consumerSecret {
-    final envValue = dotenv.env['WOO_CONSUMER_SECRET']?.trim();
-    if (envValue != null && envValue.isNotEmpty) {
-      return envValue;
+    if (dotenv.isInitialized) {
+      final envValue = dotenv.env['WOO_CONSUMER_SECRET']?.trim();
+      if (envValue != null && envValue.isNotEmpty) {
+        return envValue;
+      }
     }
     return _consumerSecretFromDartDefine;
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@ Future<void> _loadEnvironment() async {
     return;
   }
   try {
-    await dotenv.load(fileName: '.env');
+    await dotenv.maybeLoad(fileName: '.env');
   } on FlutterError catch (error) {
     debugPrint('dotenv: ${error.message}');
   } catch (error, stackTrace) {


### PR DESCRIPTION
## Summary
- use `dotenv.maybeLoad` in the application bootstrap so missing `.env` files do not throw
- guard `AppConfig` environment lookups until `flutter_dotenv` is initialized and fall back to `--dart-define` values

## Testing
- ⚠️ `flutter run --dart-define=WOO_CONSUMER_KEY=dummy --dart-define=WOO_CONSUMER_SECRET=dummy -d flutter-tester` (Flutter SDK is not installed in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f4b9b85e2c832a8f94d0b1667a3a50