### PR TITLE
Prefer trimmed first name when building user display name

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -28,10 +28,84 @@ class User {
         (dataSection?['user_id']) ??
         (customerSection?['id']);
 
+    String? _normalizedString(dynamic value) {
+      if (value is String) {
+        final trimmed = value.trim();
+        if (trimmed.isNotEmpty) {
+          return trimmed;
+        }
+      }
+      return null;
+    }
+
+    String? _lookupFirstName() {
+      final billingSection = json['billing'] is Map
+          ? Map<String, dynamic>.from(json['billing'])
+          : null;
+      final dataBillingSection = dataSection?['billing'] is Map
+          ? Map<String, dynamic>.from(dataSection!['billing'])
+          : null;
+      final customerBillingSection = customerSection?['billing'] is Map
+          ? Map<String, dynamic>.from(customerSection!['billing'])
+          : null;
+
+      final firstNameSources = [
+        json['first_name'],
+        dataSection?['first_name'],
+        customerSection?['first_name'],
+        billingSection?['first_name'],
+        dataBillingSection?['first_name'],
+        customerBillingSection?['first_name'],
+      ];
+
+      for (final source in firstNameSources) {
+        final normalized = _normalizedString(source);
+        if (normalized != null) {
+          return normalized;
+        }
+      }
+      return null;
+    }
+
+    String? _lookupDisplayOrUsername() {
+      final displaySources = [
+        json['user_display_name'],
+        dataSection?['user_display_name'],
+        customerSection?['user_display_name'],
+      ];
+
+      for (final source in displaySources) {
+        final normalized = _normalizedString(source);
+        if (normalized != null) {
+          return normalized;
+        }
+      }
+
+      final usernameSources = [
+        json['username'],
+        dataSection?['username'],
+        customerSection?['username'],
+        json['user_nicename'],
+        json['user_login'],
+      ];
+
+      for (final source in usernameSources) {
+        final normalized = _normalizedString(source);
+        if (normalized != null) {
+          return normalized;
+        }
+      }
+
+      return null;
+    }
+
+    final resolvedName =
+        _lookupFirstName() ?? _lookupDisplayOrUsername() ?? '';
+
     return User(
       id: _parseId(idSource),
       token: json["token"] ?? "",
-      username: json["user_display_name"] ?? json["first_name"] ?? "",
+      username: resolvedName,
       email: json["user_email"] ?? json["email"] ?? "",
       phone: json["phone"] ?? json["billing"]?["phone"] ?? "",
     );

--- a/test/profile_screen_test.dart
+++ b/test/profile_screen_test.dart
@@ -11,6 +11,30 @@ import 'package:creditphoneqa/screens/profile_screen.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  test('User.fromJson prefers trimmed first name and persists via UserProvider', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    final jwtResponse = {
+      'token': 'jwt-token',
+      'first_name': '  Preferred  ',
+      'user_display_name': 'Display Name',
+      'username': 'display.name',
+      'email': 'user@example.com',
+    };
+
+    final user = User.fromJson(jwtResponse);
+    expect(user.username, 'Preferred');
+
+    final provider = UserProvider();
+    provider.setUser(user);
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    final restoredProvider = UserProvider();
+    await restoredProvider.loadUserFromPrefs();
+
+    expect(restoredProvider.user?.username, 'Preferred');
+  });
+
   testWidgets('ProfileScreen shows fallback initial for empty username', (WidgetTester tester) async {
     SharedPreferences.setMockInitialValues({});
 


### PR DESCRIPTION
## Summary
- update `User.fromJson` to normalize and prioritize first names from multiple sources before falling back to display names
- ensure the preferred name survives SharedPreferences persistence via a new unit test

## Testing
- `flutter test test/profile_screen_test.dart` *(fails: flutter is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ff4a2e6194832a81f1b53f53ecde5d