### PR TITLE
Refactor notification service into singleton

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,7 +67,7 @@ Future<void> _initializeMobileApp() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
-  await NotificationService().initialize();
+  await NotificationService.instance.initialize();
 
   final userProvider = UserProvider();
   await userProvider.loadUserFromPrefs();
@@ -185,7 +185,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final NotificationService _notificationService = NotificationService();
+  final NotificationService _notificationService = NotificationService.instance;
 
   @override
   void initState() {

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -8,7 +8,7 @@ import '../services/notification_service.dart';
 
 class UserProvider extends ChangeNotifier {
   UserProvider({NotificationService? notificationService})
-      : _notificationService = notificationService ?? NotificationService();
+      : _notificationService = notificationService ?? NotificationService.instance;
 
   final NotificationService _notificationService;
   User? _user;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -137,7 +137,7 @@ class _HomeScreenState extends State<HomeScreen>
       return;
     }
 
-    final service = NotificationService();
+    final service = NotificationService.instance;
     final notificationsEnabled = await service.getNotificationsEnabled();
     if (!notificationsEnabled) {
       _cancelNotificationSubscription();
@@ -752,11 +752,11 @@ class _HomeScreenState extends State<HomeScreen>
       children: [
         _buildIconWithBackground(Icons.notifications, () {
           Navigator.pushNamed(context, '/notifications').then((_) async {
-            final count = await NotificationService().getUnreadCount();
+            final count = await NotificationService.instance.getUnreadCount();
             if (!mounted) return;
             _notificationCount.value = count;
           });
-          NotificationService().markAllAsRead();
+          NotificationService.instance.markAllAsRead();
           if (mounted) {
             _notificationCount.value = 0;
           }

--- a/lib/screens/notification_explanation_screen.dart
+++ b/lib/screens/notification_explanation_screen.dart
@@ -33,7 +33,7 @@ class NotificationExplanationScreen extends StatelessWidget {
               const Spacer(),
               ElevatedButton(
                 onPressed: () async {
-                  final notificationService = NotificationService();
+                  final notificationService = NotificationService.instance;
                   await notificationService.initialize();
                   Navigator.of(context).pop(true);
                 },

--- a/lib/screens/notifications_screen.dart
+++ b/lib/screens/notifications_screen.dart
@@ -70,7 +70,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
 
     if (user != null && user.email != null) {
       // In a real app, you might want to show specific loading for this update check
-      await NotificationService().checkOrderStatusUpdates(
+      await NotificationService.instance.checkOrderStatusUpdates(
         userEmail: user.email!,
         langCode: langCode,
       );
@@ -80,7 +80,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
     // For a better UX, marking all as read might happen after the user
     // sees the notifications for a while, or you implement individual marking.
     // For now, keeping it here as per original logic.
-    await NotificationService().markAllAsRead();
+    await NotificationService.instance.markAllAsRead();
 
     setState(() {
       _isLoading = false;

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -20,7 +20,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late TextEditingController _phoneController;
   bool notificationsEnabled = true;
   bool _isLoading = false;
-  final NotificationService _notificationService = NotificationService();
+  final NotificationService _notificationService = NotificationService.instance;
   final ApiService _apiService = ApiService(); // استخدام مثيل واحد للـ ApiService
 
   Future<void> _loadNotificationSettings() async {

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -152,7 +152,7 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
   }
 
   Future<void> _initializeNotifications() async {
-    await NotificationService().initialize();
+    await NotificationService.instance.initialize();
   }
 
   Future<void> _loadLanguage() async {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -13,11 +13,11 @@ Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   if (Firebase.apps.isEmpty) {
     await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   }
-  await NotificationService().handleBackgroundMessage(message);
+  await NotificationService.instance.handleBackgroundMessage(message);
 }
 
 class NotificationService {
-  NotificationService({
+  NotificationService._internal({
     FirebaseMessaging? firebaseMessaging,
     FlutterLocalNotificationsPlugin? localNotifications,
     ApiService? apiService,
@@ -26,6 +26,50 @@ class NotificationService {
         _localNotifications = localNotifications ?? FlutterLocalNotificationsPlugin(),
         _apiService = apiService ?? ApiService(),
         _deleteTokenOverride = deleteTokenOverride;
+
+  static NotificationService? _instance;
+
+  static NotificationService get instance =>
+      _instance ??= NotificationService._internal();
+
+  factory NotificationService({
+    FirebaseMessaging? firebaseMessaging,
+    FlutterLocalNotificationsPlugin? localNotifications,
+    ApiService? apiService,
+    Future<void> Function()? deleteTokenOverride,
+  }) {
+    if (_instance == null) {
+      _instance = NotificationService._internal(
+        firebaseMessaging: firebaseMessaging,
+        localNotifications: localNotifications,
+        apiService: apiService,
+        deleteTokenOverride: deleteTokenOverride,
+      );
+    } else if (firebaseMessaging != null ||
+        localNotifications != null ||
+        apiService != null ||
+        deleteTokenOverride != null) {
+      print(
+        'NotificationService is already initialized; duplicate configuration was ignored.',
+      );
+    }
+    return instance;
+  }
+
+  /// Resets the singleton instance. Intended for testing to inject mocks.
+  static void resetForTesting({
+    FirebaseMessaging? firebaseMessaging,
+    FlutterLocalNotificationsPlugin? localNotifications,
+    ApiService? apiService,
+    Future<void> Function()? deleteTokenOverride,
+  }) {
+    _instance = NotificationService._internal(
+      firebaseMessaging: firebaseMessaging,
+      localNotifications: localNotifications,
+      apiService: apiService,
+      deleteTokenOverride: deleteTokenOverride,
+    );
+  }
 
   final FirebaseMessaging _fcm;
   final FlutterLocalNotificationsPlugin _localNotifications;
@@ -74,8 +118,13 @@ class NotificationService {
 
     FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
 
-    _tokenRefreshSubscription ??=
-        _fcm.onTokenRefresh.listen((token) => unawaited(_handleTokenRefresh(token)));
+    if (_tokenRefreshSubscription == null) {
+      _tokenRefreshSubscription =
+          _fcm.onTokenRefresh.listen((token) => unawaited(_handleTokenRefresh(token)));
+      print('NotificationService: Token refresh listener registered.');
+    } else {
+      print('NotificationService: Token refresh listener already registered; skipping.');
+    }
 
     if (notificationsEnabled) {
       _startForegroundListener();
@@ -85,19 +134,30 @@ class NotificationService {
   }
 
   void _startForegroundListener() {
-    _foregroundSubscription ??=
-        FirebaseMessaging.onMessage.listen((RemoteMessage message) => _handleForegroundMessage(message));
+    if (_foregroundSubscription == null) {
+      _foregroundSubscription = FirebaseMessaging.onMessage
+          .listen((RemoteMessage message) => _handleForegroundMessage(message));
+      print('NotificationService: Foreground listener registered.');
+    } else {
+      print('NotificationService: Foreground listener already active; skipping.');
+    }
   }
 
   Future<void> _stopForegroundListener() async {
-    await _foregroundSubscription?.cancel();
-    _foregroundSubscription = null;
+    if (_foregroundSubscription != null) {
+      await _foregroundSubscription?.cancel();
+      _foregroundSubscription = null;
+      print('NotificationService: Foreground listener cancelled.');
+    }
   }
 
   Future<void> logoutCleanup({String? email}) async {
     await _stopForegroundListener();
-    await _tokenRefreshSubscription?.cancel();
-    _tokenRefreshSubscription = null;
+    if (_tokenRefreshSubscription != null) {
+      await _tokenRefreshSubscription?.cancel();
+      _tokenRefreshSubscription = null;
+      print('NotificationService: Token refresh listener cancelled.');
+    }
     await clearStoredData();
 
     final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- convert `NotificationService` into a singleton so listeners and state are shared across the app
- add logging around listener registration and cleanup to detect duplicate registrations
- update app entry points and screens to reference the shared notification service instance

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_69008d7c5430832a81fc1e13c95417c0