### PR TITLE
Limit stored notifications history

### DIFF
--- a/lib/screens/notifications_screen.dart
+++ b/lib/screens/notifications_screen.dart
@@ -50,6 +50,7 @@ class NotificationsScreen extends StatefulWidget {
 class _NotificationsScreenState extends State<NotificationsScreen> {
   List<Map<String, dynamic>> notifications = [];
   bool _isLoading = false; // To show a loading indicator
+  bool _hasTruncatedHistory = false;
 
   @override
   void initState() {
@@ -90,6 +91,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
   Future<void> _loadNotifications() async {
     final prefs = await SharedPreferences.getInstance();
     final notificationsList = prefs.getStringList('notifications') ?? [];
+    final truncated = prefs.getBool('notifications_truncated') ?? false;
 
     setState(() {
       notifications = notificationsList
@@ -101,6 +103,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
           final timeB = DateTime.tryParse(b['time'] ?? '') ?? DateTime(0);
           return timeB.compareTo(timeA);
         });
+      _hasTruncatedHistory = truncated;
     });
   }
 
@@ -323,13 +326,51 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
         color: AppColors.primaryColor,
         child: ListView.separated(
           padding: const EdgeInsets.all(16),
-          itemCount: notifications.length,
-          separatorBuilder: (_, __) => const SizedBox(height: 14), // More space between cards
+          itemCount: notifications.length + (_hasTruncatedHistory ? 1 : 0),
+          separatorBuilder: (_, index) {
+            final isBeforeInfoBanner =
+                _hasTruncatedHistory && index >= notifications.length - 1;
+            return SizedBox(height: isBeforeInfoBanner ? 24 : 14);
+          }, // More space between cards
           itemBuilder: (context, index) {
+            if (_hasTruncatedHistory && index == notifications.length) {
+              return _buildHistoryInfoBanner(langCode);
+            }
             final notification = notifications[index];
             return _buildNotificationCard(notification, langCode);
           },
         ),
+      ),
+    );
+  }
+
+  Widget _buildHistoryInfoBanner(String langCode) {
+    final text = langCode == 'ar'
+        ? 'تم الاحتفاظ بآخر 50 إشعارًا فقط. تم حذف الإشعارات الأقدم لتوفير المساحة.'
+        : 'Only the latest 50 notifications are kept. Older alerts have been removed to save space.';
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.blueGrey.shade50,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.blueGrey.shade100),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.info_outline, color: AppColors.primaryColor),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              text,
+              style: AppTextStyles.notificationBody.copyWith(
+                color: AppColors.primaryColor,
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -79,6 +79,8 @@ class NotificationService {
   static const String _notificationsEnabledKey = 'notifications_enabled';
   static const String _notificationsListKey = 'notifications';
   static const String _unreadCountKey = 'unread_notifications';
+  static const String _notificationsTruncatedKey = 'notifications_truncated';
+  static const int _maxStoredNotifications = 50;
   static StreamSubscription<RemoteMessage>? _foregroundSubscription;
   StreamSubscription<String>? _tokenRefreshSubscription;
 
@@ -90,6 +92,7 @@ class NotificationService {
       _unreadCountKey,
       _notificationsEnabledKey,
       'order_statuses',
+      _notificationsTruncatedKey,
     ];
 
     for (final key in keysToRemove) {
@@ -254,6 +257,7 @@ class NotificationService {
     }
     final prefs = await SharedPreferences.getInstance();
     final notifications = prefs.getStringList(_notificationsListKey) ?? [];
+    final bool wasTruncated = prefs.getBool(_notificationsTruncatedKey) ?? false;
     final unreadCount = prefs.getInt(_unreadCountKey) ?? 0;
 
     final notification = {
@@ -267,9 +271,20 @@ class NotificationService {
     };
 
     notifications.insert(0, jsonEncode(notification));
+
+    bool isTruncated = wasTruncated;
+    if (notifications.length > _maxStoredNotifications) {
+      notifications.removeRange(
+        _maxStoredNotifications,
+        notifications.length,
+      );
+      isTruncated = true;
+    }
+
     await prefs.setStringList(_notificationsListKey, notifications);
     final updatedCount = unreadCount + 1;
     await prefs.setInt(_unreadCountKey, updatedCount);
+    await prefs.setBool(_notificationsTruncatedKey, isTruncated);
     _unreadCountController.add(updatedCount);
   }
 
@@ -335,6 +350,7 @@ class NotificationService {
     final storedStatuses = prefs.getString('order_statuses') ?? '{}';
     final Map<String, String> oldStatuses = Map<String, String>.from(json.decode(storedStatuses));
     final notifications = prefs.getStringList(_notificationsListKey) ?? [];
+    bool wasTruncated = prefs.getBool(_notificationsTruncatedKey) ?? false;
     int unreadCount = prefs.getInt(_unreadCountKey) ?? 0;
 
     for (final order in orders) {
@@ -370,9 +386,18 @@ class NotificationService {
       oldStatuses[orderId] = currentStatus;
     }
 
+    if (notifications.length > _maxStoredNotifications) {
+      notifications.removeRange(
+        _maxStoredNotifications,
+        notifications.length,
+      );
+      wasTruncated = true;
+    }
+
     await prefs.setStringList(_notificationsListKey, notifications);
     await prefs.setInt(_unreadCountKey, unreadCount);
     await prefs.setString('order_statuses', json.encode(oldStatuses));
+    await prefs.setBool(_notificationsTruncatedKey, wasTruncated);
     _unreadCountController.add(unreadCount);
   }
 


### PR DESCRIPTION
## Summary
- limit stored notifications to the most recent 50 items and persist a truncation flag
- ensure manual order status checks honor the same cap when adding notifications
- surface an informational banner on the notifications screen when older notifications were trimmed

## Testing
- not run (not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_69008e6baa40832abb4c52bc4241aa0d